### PR TITLE
Misplaced `async`

### DIFF
--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -148,7 +148,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T? {
+    public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T? {
         try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
     }
 }

--- a/Sources/Bytes/RawRepresentable.swift
+++ b/Sources/Bytes/RawRepresentable.swift
@@ -287,7 +287,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
+    public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
         try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
     }
 }


### PR DESCRIPTION
Fixed a compilation issue due to a pair of misplaced `async`s.