### PR TITLE
Renamed `next(bytes:...)` Methods

### DIFF
--- a/Sources/Bytes/AsyncByteIterator.swift
+++ b/Sources/Bytes/AsyncByteIterator.swift
@@ -13,30 +13,37 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances a byte array of size `count`, or throws if it could not.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         count: Int
     ) async throws -> Bytes {
         assert(count >= 0, "count must be larger than 0")
-        return try await next(bytes: type, min: count, max: count)
+        return try await next(bytes, min: count, max: count)
+    }
+    
+    /// Please use ``next(_:count:)`` instead.
+    @available(*, deprecated, renamed: "next(_:count:)")
+    @inlinable
+    public mutating func next(bytes type: Bytes.Type, count: Int) async throws -> Bytes {
+        try await next(type, count: count)
     }
     
     /// Asynchronously advances a byte array with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
     ) async throws -> Bytes {
@@ -62,15 +69,22 @@ extension AsyncIteratorProtocol where Element == Byte {
         return result
     }
     
+    /// Please use ``next(_:min:max:)`` instead.
+    @available(*, deprecated, renamed: "next(_:min:max:)")
+    @inlinable
+    public mutating func next(bytes type: Bytes.Type, min minCount: Int, max maxCount: Int) async throws -> Bytes {
+        try await next(type, min: minCount, max: maxCount)
+    }
+    
     /// Asynchronously advances a byte array with the specified maximum size.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
     @inlinable
     public mutating func next(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         max maxCount: Int
     ) async rethrows -> Bytes {
         precondition(maxCount >= 0, "maxCount must be larger than 0")
@@ -90,33 +104,47 @@ extension AsyncIteratorProtocol where Element == Byte {
         return result
     }
     
+    /// Please use ``next(_:max:)`` instead.
+    @available(*, deprecated, renamed: "next(_:max:)")
+    @inlinable
+    public mutating func next(bytes type: Bytes.Type, max maxCount: Int) async rethrows -> Bytes {
+        try await next(type, max: maxCount)
+    }
+    
     /// Asynchronously advances a byte array of size `count`, or ends the sequence if there is no next element.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         count: Int
     ) async throws -> Bytes? {
         assert(count >= 0, "count must be larger than 0")
-        return try await nextIfPresent(bytes: type, min: count, max: count)
+        return try await nextIfPresent(bytes, min: count, max: count)
+    }
+    
+    /// Please use ``nextIfPresent(_:count:)`` instead.
+    @available(*, deprecated, renamed: "nextIfPresent(_:count:)")
+    @inlinable
+    public mutating func nextIfPresent(bytes type: Bytes.Type, count: Int) async throws -> Bytes? {
+        return try await nextIfPresent(type, count: count)
     }
     
     /// Asynchronously advances a byte array with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
     ) async throws -> Bytes? {
@@ -144,15 +172,22 @@ extension AsyncIteratorProtocol where Element == Byte {
         return result
     }
     
+    /// Please use ``nextIfPresent(_:min:max:)`` instead.
+    @available(*, deprecated, renamed: "nextIfPresent(_:min:max:)")
+    @inlinable
+    public mutating func nextIfPresent(bytes type: Bytes.Type, min minCount: Int, max maxCount: Int) async throws -> Bytes? {
+        try await nextIfPresent(type, min: minCount, max: maxCount)
+    }
+    
     /// Asynchronously advances a byte array with the specified maximum size, or ends the sequence if there is no next element.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at most `maxCount`, or `nil` if the sequence is finished.
     @inlinable
     public mutating func nextIfPresent(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         max maxCount: Int
     ) async rethrows -> Bytes? {
         precondition(maxCount >= 0, "maxCount must be larger than 0")
@@ -172,6 +207,13 @@ extension AsyncIteratorProtocol where Element == Byte {
         guard !result.isEmpty else { return nil }
         
         return result
+    }
+    
+    /// Please use ``nextIfPresent(_:max:)`` instead.
+    @available(*, deprecated, renamed: "nextIfPresent(_:max:)")
+    @inlinable
+    public mutating func nextIfPresent(bytes type: Bytes.Type, max maxCount: Int) async rethrows -> Bytes? {
+        try await nextIfPresent(type, max: maxCount)
     }
 }
 

--- a/Sources/Bytes/AsyncChunkedBytes.swift
+++ b/Sources/Bytes/AsyncChunkedBytes.swift
@@ -82,7 +82,7 @@ extension AsyncChunkedBytes: AsyncSequence {
         /// This iterator buffers bytes up to `capacity`, then returnes then as a single chunk.
         @inlinable
         public mutating func next() async rethrows -> Bytes? {
-            try await baseIterator.nextIfPresent(bytes: Bytes.self, max: capacity)
+            try await baseIterator.nextIfPresent(Bytes.self, max: capacity)
         }
     }
     

--- a/Sources/Bytes/ByteIterator.swift
+++ b/Sources/Bytes/ByteIterator.swift
@@ -10,30 +10,37 @@ extension IteratorProtocol where Element == Byte {
     /// Advances a byte array of size `count`, or throws if it could not.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         count: Int
     ) throws -> Bytes {
         assert(count >= 0, "count must be larger than 0")
-        return try next(bytes: type, min: count, max: count)
+        return try next(bytes, min: count, max: count)
+    }
+    
+    /// Please use ``next(_:count:)`` instead.
+    @available(*, deprecated, renamed: "next(_:count:)")
+    @inlinable
+    public mutating func next(bytes type: Bytes.Type, count: Int) throws -> Bytes {
+        try next(type, count: count)
     }
     
     /// Advances a byte array with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
     ) throws -> Bytes {
@@ -59,15 +66,22 @@ extension IteratorProtocol where Element == Byte {
         return result
     }
     
+    /// Please use ``next(_:min:max:)`` instead.
+    @available(*, deprecated, renamed: "next(_:min:max:)")
+    @inlinable
+    public mutating func next(bytes type: Bytes.Type, min minCount: Int, max maxCount: Int) throws -> Bytes {
+        try next(type, min: minCount, max: maxCount)
+    }
+    
     /// Advances a byte array with the specified maximum size.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
     @inlinable
     public mutating func next(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         max maxCount: Int
     ) -> Bytes {
         precondition(maxCount >= 0, "maxCount must be larger than 0")
@@ -87,33 +101,47 @@ extension IteratorProtocol where Element == Byte {
         return result
     }
     
+    /// Please use ``next(_:max:)`` instead.
+    @available(*, deprecated, renamed: "next(_:max:)")
+    @inlinable
+    public mutating func next(bytes type: Bytes.Type, max maxCount: Int) -> Bytes {
+        next(type, max: maxCount)
+    }
+    
     /// Advances a byte array of size `count`, or ends the sequence if there is no next element.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         count: Int
     ) throws -> Bytes? {
         assert(count >= 0, "count must be larger than 0")
-        return try nextIfPresent(bytes: type, min: count, max: count)
+        return try nextIfPresent(bytes, min: count, max: count)
+    }
+    
+    /// Please use ``nextIfPresent(_:count:)`` instead.
+    @available(*, deprecated, renamed: "nextIfPresent(_:count:)")
+    @inlinable
+    public mutating func nextIfPresent(bytes type: Bytes.Type, count: Int) throws -> Bytes? {
+        try nextIfPresent(type, count: count)
     }
     
     /// Advances a byte array with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
     ) throws -> Bytes? {
@@ -141,15 +169,22 @@ extension IteratorProtocol where Element == Byte {
         return result
     }
     
+    /// Please use ``nextIfPresent(_:min:max:)`` instead.
+    @available(*, deprecated, renamed: "nextIfPresent(_:min:max:)")
+    @inlinable
+    public mutating func nextIfPresent(bytes type: Bytes.Type, min minCount: Int, max maxCount: Int) throws -> Bytes? {
+        try nextIfPresent(type, min: minCount, max: maxCount)
+    }
+    
     /// Advances a byte array with the specified maximum size, or ends the sequence if there is no next element.
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
-    /// - Parameter type: This should be set to `Bytes.self`.
+    /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at most `maxCount`, or `nil` if the sequence is finished.
     @inlinable
     public mutating func nextIfPresent(
-        bytes type: Bytes.Type,
+        _ bytes: Bytes.Type,
         max maxCount: Int
     ) -> Bytes? {
         precondition(maxCount >= 0, "maxCount must be larger than 0")
@@ -169,5 +204,12 @@ extension IteratorProtocol where Element == Byte {
         guard !result.isEmpty else { return nil }
         
         return result
+    }
+    
+    /// Please use ``nextIfPresent(_:max:)`` instead.
+    @available(*, deprecated, renamed: "nextIfPresent(_:max:)")
+    @inlinable
+    public mutating func nextIfPresent(bytes type: Bytes.Type, max maxCount: Int) -> Bytes? {
+        nextIfPresent(type, max: maxCount)
     }
 }

--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -110,7 +110,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) throws -> T {
-        try T(littleEndianBytes: next(bytes: Bytes.self, count: MemoryLayout<T>.size))
+        try T(littleEndianBytes: next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -123,7 +123,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T {
-        try T(bigEndianBytes: next(bytes: Bytes.self, count: MemoryLayout<T>.size))
+        try T(bigEndianBytes: next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -136,7 +136,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) throws -> T? {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -149,7 +149,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T? {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
     }
 }
 
@@ -170,7 +170,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T {
-        try T(littleEndianBytes: await next(bytes: Bytes.self, count: MemoryLayout<T>.size))
+        try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -183,7 +183,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T {
-        try T(bigEndianBytes: await next(bytes: Bytes.self, count: MemoryLayout<T>.size))
+        try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -196,7 +196,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T? {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -209,7 +209,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T? {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
     }
 }
 

--- a/Sources/Bytes/RawRepresentable.swift
+++ b/Sources/Bytes/RawRepresentable.swift
@@ -221,7 +221,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(raw type: T.Type) throws -> T {
-        try T(rawBytes: next(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size))
+        try T(rawBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
     }
     
     /// Advances to the next raw representable in the squence and returns it, or ends the sequence if there is no next element.
@@ -234,7 +234,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(raw type: T.Type) throws -> T? {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
     }
 }
 
@@ -249,7 +249,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(littleEndian type: T.Type) throws -> T where T.RawValue: FixedWidthInteger {
-        try T(littleEndianBytes: next(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size))
+        try T(littleEndianBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -262,7 +262,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(bigEndian type: T.Type) throws -> T where T.RawValue: FixedWidthInteger {
-        try T(bigEndianBytes: next(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size))
+        try T(bigEndianBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
     }
     
     /// Advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -275,7 +275,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(littleEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -288,7 +288,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
     }
 }
 
@@ -309,7 +309,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(raw type: T.Type) async throws -> T {
-        try T(rawBytes: await next(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size))
+        try T(rawBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
     }
     
     /// Asynchronously advances to the next raw representable in the squence and returns it, or ends the sequence if there is no next element.
@@ -322,7 +322,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(raw type: T.Type) async throws -> T? {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
     }
 }
 
@@ -338,7 +338,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(littleEndian type: T.Type) async throws -> T where T.RawValue: FixedWidthInteger {
-        try T(littleEndianBytes: await next(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size))
+        try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -351,7 +351,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T where T.RawValue: FixedWidthInteger {
-        try T(bigEndianBytes: await next(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size))
+        try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
     }
     
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -364,7 +364,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(littleEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -377,7 +377,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
     }
 }
 

--- a/Sources/Bytes/String.swift
+++ b/Sources/Bytes/String.swift
@@ -54,7 +54,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(utf8 type: String.Type, count: Int) throws -> String {
-        String(utf8Bytes: try next(bytes: Bytes.self, count: count))
+        String(utf8Bytes: try next(Bytes.self, count: count))
     }
     
     /// Advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
@@ -67,7 +67,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) throws -> String {
-        String(utf8Bytes: try next(bytes: Bytes.self, min: minCount, max: maxCount))
+        String(utf8Bytes: try next(Bytes.self, min: minCount, max: maxCount))
     }
     
     /// Advances to the UTF-8 encoded String of size `count`, or ends the sequence if there is no next element.
@@ -79,7 +79,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(utf8 type: String.Type, count: Int) throws -> String? {
-        try nextIfPresent(bytes: Bytes.self, count: count).map { String(utf8Bytes: $0) }
+        try nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
     }
     
     /// Advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
@@ -92,7 +92,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) throws -> String? {
-        try nextIfPresent(bytes: Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
+        try nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
     }
 }
 
@@ -112,7 +112,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(utf8 type: String.Type, count: Int) async throws -> String {
-        String(utf8Bytes: try await next(bytes: Bytes.self, count: count))
+        String(utf8Bytes: try await next(Bytes.self, count: count))
     }
     
     /// Asynchronously advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
@@ -125,7 +125,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String {
-        String(utf8Bytes: try await next(bytes: Bytes.self, min: minCount, max: maxCount))
+        String(utf8Bytes: try await next(Bytes.self, min: minCount, max: maxCount))
     }
     
     /// Asynchronously advances to the UTF-8 encoded String of size `count`, or ends the sequence if there is no next element.
@@ -137,7 +137,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(utf8 type: String.Type, count: Int) async throws -> String? {
-        try await nextIfPresent(bytes: Bytes.self, count: count).map { String(utf8Bytes: $0) }
+        try await nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
     }
     
     /// Asynchronously advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
@@ -150,7 +150,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String? {
-        try await nextIfPresent(bytes: Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
+        try await nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
     }
 }
 

--- a/Sources/Bytes/UUID.swift
+++ b/Sources/Bytes/UUID.swift
@@ -133,7 +133,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
     @inlinable
     public mutating func next(_ type: UUID.Type) throws -> UUID {
-        try UUID(bytes: next(bytes: Bytes.self, count: MemoryLayout<uuid_t>.size))
+        try UUID(bytes: next(Bytes.self, count: MemoryLayout<uuid_t>.size))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -144,7 +144,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
     @inlinable
     public mutating func next(string type: UUID.Type) throws -> UUID {
-        try UUID(stringBytes: next(bytes: Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
+        try UUID(stringBytes: next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
     }
     
     /// Asynchronously advances to the next binary UUID, or ends the sequence if there is no next element.
@@ -155,7 +155,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
     @inlinable
     public mutating func nextIfPresent(_ type: UUID.Type) throws -> UUID? {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
     }
     
     /// Asynchronously advances to the next UUID String, or ends the sequence if there is no next element.
@@ -166,7 +166,7 @@ extension IteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
     @inlinable
     public mutating func nextIfPresent(string type: UUID.Type) throws -> UUID? {
-        try nextIfPresent(bytes: Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
+        try nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
     }
 }
 
@@ -185,7 +185,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
     @inlinable
     public mutating func next(_ type: UUID.Type) async throws -> UUID {
-        try UUID(bytes: await next(bytes: Bytes.self, count: MemoryLayout<uuid_t>.size))
+        try UUID(bytes: await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -196,7 +196,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
     @inlinable
     public mutating func next(string type: UUID.Type) async throws -> UUID {
-        try UUID(stringBytes: await next(bytes: Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
+        try UUID(stringBytes: await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
     }
     
     /// Asynchronously advances to the next binary UUID, or ends the sequence if there is no next element.
@@ -207,7 +207,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
     @inlinable
     public mutating func nextIfPresent(_ type: UUID.Type) async throws -> UUID? {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
     }
     
     /// Asynchronously advances to the next UUID String, or ends the sequence if there is no next element.
@@ -218,7 +218,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
     @inlinable
     public mutating func nextIfPresent(string type: UUID.Type) async throws -> UUID? {
-        try await nextIfPresent(bytes: Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
     }
 }
 


### PR DESCRIPTION
Renamed next(IfPresent)(bytes:) methods.