### PR TITLE
Full Swift 6 Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@
 import PackageDescription
 
 let swiftSettings: [PackageDescription.SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny"),
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+//
+//  Package.swift
+//  https://github.com/mochidev/Bytes
+//
+//  Created by Dimitri Bouniol on 2026-05-06.
+//  Copyright © 2020-26 Mochi Development, Inc. All rights reserved.
+//  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
+//
+
+import PackageDescription
+
+let swiftSettings: [PackageDescription.SwiftSetting] = [
+]
+
+let package = Package(
+    name: "Bytes",
+    products: [
+        .library(
+            name: "Bytes",
+            targets: ["Bytes"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Bytes",
+            dependencies: [],
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
+            name: "BytesTests",
+            dependencies: ["Bytes"],
+            swiftSettings: swiftSettings
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ import PackageDescription
 
 let swiftSettings: [PackageDescription.SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
 ]
 
 let package = Package(

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -10,29 +10,25 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
-
 import PackageDescription
 
 let package = Package(
     name: "Bytes",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Bytes",
-            targets: ["Bytes"]),
+            targets: ["Bytes"]
+        ),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Bytes",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "BytesTests",
-            dependencies: ["Bytes"]),
+            dependencies: ["Bytes"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Bytes can also be used to pull data from `AsyncSequence` iterators. To learn mor
 
 For instance, improving the above example:
 ```swift
-#if compiler(>=5.5) && canImport(_Concurrency)
+import Bytes
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
@@ -178,8 +178,6 @@ extension AsyncIteratorProtocol where Element == Byte {
         )
     }
 }
-
-#endif
 ```
 
 ## Contributing

--- a/Sources/Bytes/AsyncByteIterator.swift
+++ b/Sources/Bytes/AsyncByteIterator.swift
@@ -7,8 +7,6 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances a byte array of size `count`, or throws if it could not.
@@ -301,5 +299,3 @@ extension AsyncIteratorProtocol where Element == Byte {
         return true
     }
 }
-
-#endif

--- a/Sources/Bytes/AsyncByteIterator.swift
+++ b/Sources/Bytes/AsyncByteIterator.swift
@@ -16,6 +16,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
     /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
@@ -27,6 +30,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     
     /// Please use ``next(_:count:)`` instead.
     @available(*, deprecated, renamed: "next(_:count:)")
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(bytes type: Bytes.Type, count: Int) async throws -> Bytes {
         try await next(type, count: count)
@@ -40,6 +46,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
     /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
@@ -70,6 +79,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     
     /// Please use ``next(_:min:max:)`` instead.
     @available(*, deprecated, renamed: "next(_:min:max:)")
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(bytes type: Bytes.Type, min minCount: Int, max maxCount: Int) async throws -> Bytes {
         try await next(type, min: minCount, max: maxCount)
@@ -81,6 +93,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
@@ -105,6 +120,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     
     /// Please use ``next(_:max:)`` instead.
     @available(*, deprecated, renamed: "next(_:max:)")
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(bytes type: Bytes.Type, max maxCount: Int) async rethrows -> Bytes {
         try await next(type, max: maxCount)
@@ -117,6 +135,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
     /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
@@ -128,6 +149,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     
     /// Please use ``nextIfPresent(_:count:)`` instead.
     @available(*, deprecated, renamed: "nextIfPresent(_:count:)")
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(bytes type: Bytes.Type, count: Int) async throws -> Bytes? {
         return try await nextIfPresent(type, count: count)
@@ -141,6 +165,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
     /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
@@ -173,6 +200,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     
     /// Please use ``nextIfPresent(_:min:max:)`` instead.
     @available(*, deprecated, renamed: "nextIfPresent(_:min:max:)")
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(bytes type: Bytes.Type, min minCount: Int, max maxCount: Int) async throws -> Bytes? {
         try await nextIfPresent(type, min: minCount, max: maxCount)
@@ -184,6 +214,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at most `maxCount`, or `nil` if the sequence is finished.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
@@ -210,6 +243,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     
     /// Please use ``nextIfPresent(_:max:)`` instead.
     @available(*, deprecated, renamed: "nextIfPresent(_:max:)")
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(bytes type: Bytes.Type, max maxCount: Int) async rethrows -> Bytes? {
         try await nextIfPresent(type, max: maxCount)
@@ -222,6 +258,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check(
         _ byte: UInt8
@@ -241,6 +280,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<Bytes: BytesCollection>(
         _ bytes: Bytes
@@ -258,6 +300,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter byte: The byte to check for.
     /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
@@ -281,6 +326,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: The bytes to check for.
     /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Bytes: BytesCollection>(

--- a/Sources/Bytes/AsyncChunkedBytes.swift
+++ b/Sources/Bytes/AsyncChunkedBytes.swift
@@ -79,6 +79,9 @@ extension AsyncChunkedBytes: AsyncSequence {
         /// Produces the next element in the chunked sequence.
         ///
         /// This iterator buffers bytes up to `capacity`, then returnes then as a single chunk.
+        #if swift(>=6.2)
+        @concurrent
+        #endif
         @inlinable
         public mutating func next() async rethrows -> Bytes? {
             try await baseIterator.nextIfPresent(Bytes.self, max: capacity)

--- a/Sources/Bytes/AsyncChunkedBytes.swift
+++ b/Sources/Bytes/AsyncChunkedBytes.swift
@@ -7,8 +7,6 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence where Element == Byte {
     /// Creates an asynchronous sequence that splits the receiving sequence into chunks of uniform size.
@@ -92,5 +90,3 @@ extension AsyncChunkedBytes: AsyncSequence {
         AsyncIterator(base.makeAsyncIterator(), capacity: capacity)
     }
 }
-
-#endif

--- a/Sources/Bytes/Bytes.docc/Bytes.md
+++ b/Sources/Bytes/Bytes.docc/Bytes.md
@@ -128,7 +128,7 @@ Bytes can also be used to pull data from `AsyncSequence` iterators. To learn mor
 
 For instance, improving the above example:
 ```swift
-#if compiler(>=5.5) && canImport(_Concurrency)
+import Bytes
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
@@ -141,6 +141,4 @@ extension AsyncIteratorProtocol where Element == Byte {
         )
     }
 }
-
-#endif
 ```

--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -10,7 +10,7 @@
 public typealias Byte = UInt8
 
 /// A type that has the same API as `Bytes`, `BytesSlice`, and `ContiguousBytes`.
-public protocol BytesCollection: CustomDebugStringConvertible, CustomReflectable, CustomStringConvertible, ExpressibleByArrayLiteral, MutableCollection, RandomAccessCollection, RangeReplaceableCollection where Element == Byte, Index == Int, SubSequence: BytesCollection {}
+public protocol BytesCollection: CustomDebugStringConvertible, CustomReflectable, CustomStringConvertible, ExpressibleByArrayLiteral, MutableCollection, RandomAccessCollection, RangeReplaceableCollection, Sendable where Element == Byte, Index == Int, SubSequence: BytesCollection {}
 
 public typealias Bytes = Array<Byte>
 extension Bytes: BytesCollection {}

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -7,7 +7,7 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
-extension BidirectionalCollection where Element == Byte {
+extension Collection where Element == Byte {
     /// Check if a sequence of Bytes can be safely casted to an element.
     /// - Parameter target: The type of element to cast to.
     /// - Throws: `BytesError.invalidMemorySize` if the size of the bytes sequence is not equal to the element's size.

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -7,8 +7,6 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
-import Foundation
-
 extension BidirectionalCollection where Element == Byte {
     /// Check if a sequence of Bytes can be safely casted to an element.
     /// - Parameter target: The type of element to cast to.
@@ -41,7 +39,7 @@ extension BidirectionalCollection where Element == Byte {
         try canBeCasted(to: R.self)
         
         if let result = self.withContiguousStorageIfAvailable({
-            $0.withUnsafeBytes { $0.loadUnaligned(as: R.self) }
+            UnsafeRawBufferPointer($0).loadUnaligned(as: R.self)
         }) {
             return result
         }

--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -217,8 +217,6 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or throws if it could not.
@@ -333,5 +331,3 @@ extension AsyncIteratorProtocol where Element == Byte {
         try await checkIfPresent(integer.bigEndianBytes)
     }
 }
-
-#endif

--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -227,6 +227,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T {
         try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
@@ -240,6 +243,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T {
         try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
@@ -253,6 +259,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
@@ -266,6 +275,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
@@ -278,6 +290,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<Int: FixedWidthInteger>(
         littleEndian integer: Int
@@ -292,6 +307,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<Int: FixedWidthInteger>(
         bigEndian integer: Int
@@ -307,6 +325,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
@@ -323,6 +344,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(

--- a/Sources/Bytes/RawRepresentable.swift
+++ b/Sources/Bytes/RawRepresentable.swift
@@ -496,6 +496,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next<T: RawRepresentable>(raw type: T.Type) async throws -> T {
         try T(rawBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
@@ -509,6 +512,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(raw type: T.Type) async throws -> T? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
@@ -521,6 +527,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter value: The raw value to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<Raw: RawRepresentable>(
         raw value: Raw
@@ -536,6 +545,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter value: The raw value to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Raw: RawRepresentable>(
@@ -555,6 +567,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next<T: RawRepresentable>(littleEndian type: T.Type) async throws -> T where T.RawValue: FixedWidthInteger {
         try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
@@ -568,6 +583,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T where T.RawValue: FixedWidthInteger {
         try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
@@ -581,6 +599,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(littleEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
@@ -594,6 +615,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
@@ -606,6 +630,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<RawInt: RawRepresentable>(
         _ integer: RawInt
@@ -620,6 +647,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<RawInt: RawRepresentable>(
         littleEndian integer: RawInt
@@ -634,6 +664,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<RawInt: RawRepresentable>(
         bigEndian integer: RawInt
@@ -649,6 +682,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
@@ -665,6 +701,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
@@ -681,6 +720,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
@@ -699,6 +741,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<RawCharacter: RawRepresentable>(
         utf8 character: RawCharacter
@@ -717,6 +762,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<RawString: RawRepresentable>(
         utf8 string: RawString
@@ -732,6 +780,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter character: The character to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawCharacter: RawRepresentable>(
@@ -752,6 +803,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawString: RawRepresentable>(

--- a/Sources/Bytes/RawRepresentable.swift
+++ b/Sources/Bytes/RawRepresentable.swift
@@ -486,8 +486,6 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next raw representable in the squence and returns it, or throws if it could not.
@@ -762,5 +760,3 @@ extension AsyncIteratorProtocol where Element == Byte {
         try await checkIfPresent(string.utf8Bytes)
     }
 }
-
-#endif

--- a/Sources/Bytes/String.swift
+++ b/Sources/Bytes/String.swift
@@ -168,8 +168,6 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the UTF-8 encoded String of size `count`, or throws if it could not.
@@ -260,5 +258,3 @@ extension AsyncIteratorProtocol where Element == Byte {
         try await checkIfPresent(string.utf8Bytes)
     }
 }
-
-#endif

--- a/Sources/Bytes/String.swift
+++ b/Sources/Bytes/String.swift
@@ -177,6 +177,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(utf8 type: String.Type, count: Int) async throws -> String {
         String(utf8Bytes: try await next(Bytes.self, count: count))
@@ -190,6 +193,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`.
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String {
         String(utf8Bytes: try await next(Bytes.self, min: minCount, max: maxCount))
@@ -202,6 +208,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(utf8 type: String.Type, count: Int) async throws -> String? {
         try await nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
@@ -215,6 +224,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String? {
         try await nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
@@ -231,6 +243,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check<String: StringProtocol>(
         utf8 string: String
@@ -250,6 +265,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<String: StringProtocol>(

--- a/Sources/Bytes/UUID.swift
+++ b/Sources/Bytes/UUID.swift
@@ -242,8 +242,6 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next binary UUID, or throws if it could not.
@@ -358,5 +356,3 @@ extension AsyncIteratorProtocol where Element == Byte {
         return true
     }
 }
-
-#endif

--- a/Sources/Bytes/UUID.swift
+++ b/Sources/Bytes/UUID.swift
@@ -7,7 +7,11 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
+#if swift(>=6)
+public import Foundation
+#else
 import Foundation
+#endif
 
 /// Internal structure to use when measuring UUID bytes in collections
 @usableFromInline
@@ -250,6 +254,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID.
     /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(_ type: UUID.Type) async throws -> UUID {
         try UUID(bytes: await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
@@ -261,6 +268,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID.
     /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func next(string type: UUID.Type) async throws -> UUID {
         try UUID(stringBytes: await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
@@ -272,6 +282,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(_ type: UUID.Type) async throws -> UUID? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
@@ -283,6 +296,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID, or `nil` if the sequence is finished.
     /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func nextIfPresent(string type: UUID.Type) async throws -> UUID? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
@@ -295,6 +311,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check(
         _ uuid: UUID
@@ -309,6 +328,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     public mutating func check(
         string uuid: UUID
@@ -327,6 +349,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter uuid: The UUID to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
@@ -343,6 +368,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter uuid: The UUID to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
     /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    #if swift(>=6.2)
+    @concurrent
+    #endif
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -24,13 +24,13 @@ extension BytesError {
         let messageResult = message()
         
         if case let Self.invalidMemorySize(a1, a2, a3) = expressionResult {
-            XCTAssertEqual(a1, try targetSize(), messageResult, file: file, line: line)
-            XCTAssertEqual(a2, try targetType(), messageResult, file: file, line: line)
-            XCTAssertEqual(a3, try actualSize(), messageResult, file: file, line: line)
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidMemorySize", file: file, line: line)
+            XCTFail("\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
         } else {
-            XCTFail(messageResult, file: file, line: line)
+            XCTFail(messageResult, file: (file), line: line)
         }
     }
     
@@ -45,16 +45,16 @@ extension BytesError {
         let messageResult = message()
         
         if case let Self.contiguousMemoryUnavailable(a1) = expressionResult {
-            XCTAssertEqual(a1, try collectionType(), messageResult, file: file, line: line)
+            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: file, line: line)
+            XCTFail("\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
         } else {
-            XCTFail(messageResult, file: file, line: line)
+            XCTFail(messageResult, file: (file), line: line)
         }
     }
     
     static func testInvalidCharacterByteSequence(
-        _ expression: @autoclosure () throws -> Error,
+        _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
         line: UInt = #line) rethrows {
@@ -64,9 +64,9 @@ extension BytesError {
         
         if case Self.invalidCharacterByteSequence = expressionResult {
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: file, line: line)
+            XCTFail("\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
         } else {
-            XCTFail(messageResult, file: file, line: line)
+            XCTFail(messageResult, file: (file), line: line)
         }
     }
     
@@ -81,9 +81,9 @@ extension BytesError {
         
         if case Self.invalidRawRepresentableByteSequence = expressionResult {
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: file, line: line)
+            XCTFail("\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
         } else {
-            XCTFail(messageResult, file: file, line: line)
+            XCTFail(messageResult, file: (file), line: line)
         }
     }
     
@@ -98,9 +98,9 @@ extension BytesError {
         
         if case Self.invalidUUIDByteSequence = expressionResult {
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: file, line: line)
+            XCTFail("\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)
         } else {
-            XCTFail(messageResult, file: file, line: line)
+            XCTFail(messageResult, file: (file), line: line)
         }
     }
 }

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -12,7 +12,7 @@ import Bytes
 
 extension BytesError {
     static func testInvalidMemorySize(
-        _ expression: @autoclosure () throws -> Error,
+        _ expression: @autoclosure () throws -> any Error,
         targetSize: @autoclosure () throws -> Int,
         targetType: @autoclosure () throws -> String,
         actualSize: @autoclosure () throws -> Int,
@@ -35,7 +35,7 @@ extension BytesError {
     }
     
     static func testContiguousMemoryUnavailable(
-        _ expression: @autoclosure () throws -> Error,
+        _ expression: @autoclosure () throws -> any Error,
         collectionType: @autoclosure () throws -> String,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
@@ -71,7 +71,7 @@ extension BytesError {
     }
     
     static func testInvalidRawRepresentableByteSequence(
-        _ expression: @autoclosure () throws -> Error,
+        _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
         line: UInt = #line) rethrows {
@@ -88,7 +88,7 @@ extension BytesError {
     }
     
     static func testInvalidUUIDByteSequence(
-        _ expression: @autoclosure () throws -> Error,
+        _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
         line: UInt = #line) rethrows {


### PR DESCRIPTION
- Removed compiler checks for Swift 5.5
- Migrated Package to Swift 5 version
- Added baseline support for the Swift 6 language mode
- Updated package to support existential any
- Added support for other Swift 6 upcoming features
- Updated casting methods to be available on `Collection` instead of just `BidirectionalCollection`