### PR TITLE
Typed Throws

### DIFF
--- a/Sources/Bytes/AsyncByteIterator.swift
+++ b/Sources/Bytes/AsyncByteIterator.swift
@@ -7,6 +7,7 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances a byte array of size `count`, or throws if it could not.
@@ -15,15 +16,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next(
         _ bytes: Bytes.Type,
         count: Int
-    ) async throws -> Bytes {
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> Bytes {
         assert(count >= 0, "count must be larger than 0")
         return try await next(bytes, min: count, max: count)
     }
@@ -35,16 +39,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) async throws -> Bytes {
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> Bytes {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -52,16 +59,20 @@ extension AsyncIteratorProtocol where Element == Byte {
         var result = Bytes()
         result.reserveCapacity(minCount)
         
-        while let next = try await next() {
-            result.append(next)
-            
-            if result.count == maxCount {
-                return result
+        do {
+            while let next = try await next() {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
             }
+        } catch {
+            throw .iterationFailure(error)
         }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .invalidBufferSize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
         }
         
         return result
@@ -77,6 +88,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next(
         _ bytes: Bytes.Type,
         max maxCount: Int
@@ -104,15 +116,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         count: Int
-    ) async throws -> Bytes? {
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> Bytes? {
         assert(count >= 0, "count must be larger than 0")
         return try await nextIfPresent(bytes, min: count, max: count)
     }
@@ -124,16 +139,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) async throws -> Bytes? {
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> Bytes? {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -141,18 +159,22 @@ extension AsyncIteratorProtocol where Element == Byte {
         var result = Bytes()
         result.reserveCapacity(minCount)
         
-        while let next = try await next() {
-            result.append(next)
-            
-            if result.count == maxCount {
-                return result
+        do {
+            while let next = try await next() {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
             }
+        } catch {
+            throw .iterationFailure(error)
         }
         
         guard !result.isEmpty else { return nil }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .invalidBufferSize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
         }
         
         return result
@@ -168,6 +190,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         max maxCount: Int
@@ -197,17 +220,25 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check(
         _ byte: UInt8
-    ) async throws {
-        let value = try await next()
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
+        let value: Element?
+        do {
+            value = try await next()
+        } catch {
+            throw .iterationFailure(error)
+        }
         if value != byte {
-            throw BytesError.checkedSequenceNotFound
+            throw .checkedSequenceNotFound
         }
     }
     
@@ -219,14 +250,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) async throws {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
         for byte in bytes {
             try await check(byte)
         }
@@ -239,18 +273,27 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
     /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
     @discardableResult
+    @_disfavoredOverload
     public mutating func checkIfPresent(
         _ byte: UInt8
-    ) async throws -> Bool {
-        guard let value = try await next() else { return false }
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
+        let value: Element?
+        do {
+            value = try await next()
+        } catch {
+            throw .iterationFailure(error)
+        }
+        guard let value else { return false }
         if value != byte {
-            throw BytesError.checkedSequenceNotFound
+            throw .checkedSequenceNotFound
         }
         
         return true
@@ -265,15 +308,325 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
     /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
     @discardableResult
+    @_disfavoredOverload
     public mutating func checkIfPresent<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) async throws -> Bool {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
+        var first = true
+        for byte in bytes {
+            if first {
+                guard try await checkIfPresent(byte) else { return false }
+                first = false
+            } else {
+                try await check(byte)
+            }
+        }
+        
+        return true
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances a byte array of size `count`, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter count: The number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size `count`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next(
+        _ bytes: Bytes.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> Bytes {
+        assert(count >= 0, "count must be larger than 0")
+        return try await next(bytes, min: count, max: count)
+    }
+    
+    /// Asynchronously advances a byte array with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a byte array.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next(
+        _ bytes: Bytes.Type,
+        min minCount: Int,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> Bytes {
+        precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
+        precondition(minCount >= 0, "minCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(minCount)
+        
+        do {
+            while let next = try await next(isolation: actor) {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
+            }
+        } catch {
+            throw .iterationFailure(error)
+        }
+        
+        guard result.count >= minCount else {
+            throw .invalidBufferSize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+        }
+        
+        return result
+    }
+    
+    /// Asynchronously advances a byte array with the specified maximum size.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
+    @inlinable
+    public mutating func next(
+        _ bytes: Bytes.Type,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(Failure) -> Bytes {
+        precondition(maxCount >= 0, "maxCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(maxCount)
+        
+        while let next = try await next(isolation: actor) {
+            result.append(next)
+            
+            if result.count == maxCount {
+                return result
+            }
+        }
+        
+        return result
+    }
+    
+    /// Asynchronously advances a byte array of size `count`, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter count: The number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ bytes: Bytes.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> Bytes? {
+        assert(count >= 0, "count must be larger than 0")
+        return try await nextIfPresent(bytes, min: count, max: count)
+    }
+    
+    /// Asynchronously advances a byte array with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a byte array.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ bytes: Bytes.Type,
+        min minCount: Int,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> Bytes? {
+        precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
+        precondition(minCount >= 0, "minCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(minCount)
+        
+        do {
+            while let next = try await next(isolation: actor) {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
+            }
+        } catch {
+            throw .iterationFailure(error)
+        }
+        
+        guard !result.isEmpty else { return nil }
+        
+        guard result.count >= minCount else {
+            throw .invalidBufferSize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+        }
+        
+        return result
+    }
+    
+    /// Asynchronously advances a byte array with the specified maximum size, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Returns: A byte array of size at most `maxCount`, or `nil` if the sequence is finished.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ bytes: Bytes.Type,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(Failure) -> Bytes? {
+        precondition(maxCount >= 0, "maxCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(maxCount)
+        
+        while let next = try await next(isolation: actor) {
+            result.append(next)
+            
+            if result.count == maxCount {
+                return result
+            }
+        }
+        
+        guard !result.isEmpty else { return nil }
+        
+        return result
+    }
+    
+    /// Asynchronously advances by the specified byte if found, or throws if the next byte does not match.
+    ///
+    /// Use this method when you expect a byte to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter byte: The byte to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check(
+        _ byte: UInt8,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        let value: Element?
+        do {
+            value = try await next(isolation: actor)
+        } catch {
+            throw .iterationFailure(error)
+        }
+        if value != byte {
+            throw .checkedSequenceNotFound
+        }
+    }
+    
+    /// Asynchronously advances by the specified bytes if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a collection of bytes to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the bytes collection is an empty array, this method won't do anything.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: The bytes to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<Bytes: BytesCollection>(
+        _ bytes: Bytes,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        for byte in bytes {
+            try await check(byte)
+        }
+    }
+    
+    /// Asynchronously advances by the specified byte if found, throws if the next byte does not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a byte to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter byte: The byte to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent(
+        _ byte: UInt8,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
+        let value: Element?
+        do {
+            value = try await next(isolation: actor)
+        } catch {
+            throw .iterationFailure(error)
+        }
+        guard let value else { return false }
+        if value != byte {
+            throw .checkedSequenceNotFound
+        }
+        
+        return true
+    }
+    
+    /// Asynchronously advances by the specified bytes if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a collection of bytes to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the bytes collection is an empty array, this method won't do anything.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: The bytes to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Bytes: BytesCollection>(
+        _ bytes: Bytes,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
         var first = true
         for byte in bytes {
             if first {

--- a/Sources/Bytes/AsyncByteIterator.swift
+++ b/Sources/Bytes/AsyncByteIterator.swift
@@ -7,6 +7,7 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances a byte array of size `count`, or throws if it could not.
@@ -15,15 +16,16 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next(
         _ bytes: Bytes.Type,
         count: Int
-    ) async throws -> Bytes {
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> Bytes {
         assert(count >= 0, "count must be larger than 0")
         return try await next(bytes, min: count, max: count)
     }
@@ -35,16 +37,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) async throws -> Bytes {
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> Bytes {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -52,16 +55,20 @@ extension AsyncIteratorProtocol where Element == Byte {
         var result = Bytes()
         result.reserveCapacity(minCount)
         
-        while let next = try await next() {
-            result.append(next)
-            
-            if result.count == maxCount {
-                return result
+        do {
+            while let next = try await next() {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
             }
+        } catch {
+            throw .iterationFailure(error)
         }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .consumptionFailure(.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count))
         }
         
         return result
@@ -77,6 +84,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next(
         _ bytes: Bytes.Type,
         max maxCount: Int
@@ -104,15 +112,16 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         count: Int
-    ) async throws -> Bytes? {
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> Bytes? {
         assert(count >= 0, "count must be larger than 0")
         return try await nextIfPresent(bytes, min: count, max: count)
     }
@@ -124,16 +133,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) async throws -> Bytes? {
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> Bytes? {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -141,18 +151,22 @@ extension AsyncIteratorProtocol where Element == Byte {
         var result = Bytes()
         result.reserveCapacity(minCount)
         
-        while let next = try await next() {
-            result.append(next)
-            
-            if result.count == maxCount {
-                return result
+        do {
+            while let next = try await next() {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
             }
+        } catch {
+            throw .iterationFailure(error)
         }
         
         guard !result.isEmpty else { return nil }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .consumptionFailure(.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count))
         }
         
         return result
@@ -168,6 +182,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         max maxCount: Int
@@ -197,17 +212,23 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check(
         _ byte: UInt8
-    ) async throws {
-        let value = try await next()
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<any Error>) {
+        let value: Element?
+        do {
+            value = try await next()
+        } catch {
+            throw .iterationFailure(error)
+        }
         if value != byte {
-            throw BytesError.checkedSequenceNotFound
+            throw .consumptionFailure(.checkedSequenceNotFound)
         }
     }
     
@@ -219,14 +240,15 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) async throws {
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<any Error>) {
         for byte in bytes {
             try await check(byte)
         }
@@ -239,18 +261,25 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
     /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
     @discardableResult
+    @_disfavoredOverload
     public mutating func checkIfPresent(
         _ byte: UInt8
-    ) async throws -> Bool {
-        guard let value = try await next() else { return false }
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<any Error>) -> Bool {
+        let value: Element?
+        do {
+            value = try await next()
+        } catch {
+            throw .iterationFailure(error)
+        }
+        guard let value else { return false }
         if value != byte {
-            throw BytesError.checkedSequenceNotFound
+            throw .consumptionFailure(.checkedSequenceNotFound)
         }
         
         return true
@@ -265,15 +294,307 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
     /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified, or another error if the iterator throws.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
     @discardableResult
+    @_disfavoredOverload
     public mutating func checkIfPresent<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) async throws -> Bool {
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<any Error>) -> Bool {
+        var first = true
+        for byte in bytes {
+            if first {
+                guard try await checkIfPresent(byte) else { return false }
+                first = false
+            } else {
+                try await check(byte)
+            }
+        }
+        
+        return true
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances a byte array of size `count`, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter count: The number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size `count`.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func next(
+        _ bytes: Bytes.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> Bytes {
+        assert(count >= 0, "count must be larger than 0")
+        return try await next(bytes, min: count, max: count)
+    }
+    
+    /// Asynchronously advances a byte array with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a byte array.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func next(
+        _ bytes: Bytes.Type,
+        min minCount: Int,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> Bytes {
+        precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
+        precondition(minCount >= 0, "minCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(minCount)
+        
+        do {
+            while let next = try await next(isolation: actor) {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
+            }
+        } catch {
+            throw .iterationFailure(error)
+        }
+        
+        guard result.count >= minCount else {
+            throw .consumptionFailure(.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count))
+        }
+        
+        return result
+    }
+    
+    /// Asynchronously advances a byte array with the specified maximum size.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
+    @inlinable
+    public mutating func next(
+        _ bytes: Bytes.Type,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(Failure) -> Bytes {
+        precondition(maxCount >= 0, "maxCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(maxCount)
+        
+        while let next = try await next(isolation: actor) {
+            result.append(next)
+            
+            if result.count == maxCount {
+                return result
+            }
+        }
+        
+        return result
+    }
+    
+    /// Asynchronously advances a byte array of size `count`, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter count: The number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ bytes: Bytes.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> Bytes? {
+        assert(count >= 0, "count must be larger than 0")
+        return try await nextIfPresent(bytes, min: count, max: count)
+    }
+    
+    /// Asynchronously advances a byte array with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a byte array.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete byte array could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ bytes: Bytes.Type,
+        min minCount: Int,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> Bytes? {
+        precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
+        precondition(minCount >= 0, "minCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(minCount)
+        
+        do {
+            while let next = try await next(isolation: actor) {
+                result.append(next)
+                
+                if result.count == maxCount {
+                    return result
+                }
+            }
+        } catch {
+            throw .iterationFailure(error)
+        }
+        
+        guard !result.isEmpty else { return nil }
+        
+        guard result.count >= minCount else {
+            throw .consumptionFailure(.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count))
+        }
+        
+        return result
+    }
+    
+    /// Asynchronously advances a byte array with the specified maximum size, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: This should be set to `Bytes.self`.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
+    /// - Returns: A byte array of size at most `maxCount`, or `nil` if the sequence is finished.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ bytes: Bytes.Type,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(Failure) -> Bytes? {
+        precondition(maxCount >= 0, "maxCount must be larger than 0")
+        guard maxCount > 0 else { return [] }
+        
+        var result = Bytes()
+        result.reserveCapacity(maxCount)
+        
+        while let next = try await next(isolation: actor) {
+            result.append(next)
+            
+            if result.count == maxCount {
+                return result
+            }
+        }
+        
+        guard !result.isEmpty else { return nil }
+        
+        return result
+    }
+    
+    /// Asynchronously advances by the specified byte if found, or throws if the next byte does not match.
+    ///
+    /// Use this method when you expect a byte to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter byte: The byte to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified.
+    @inlinable
+    public mutating func check(
+        _ byte: UInt8,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) {
+        let value: Element?
+        do {
+            value = try await next(isolation: actor)
+        } catch {
+            throw .iterationFailure(error)
+        }
+        if value != byte {
+            throw .consumptionFailure(.checkedSequenceNotFound)
+        }
+    }
+    
+    /// Asynchronously advances by the specified bytes if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a collection of bytes to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the bytes collection is an empty array, this method won't do anything.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: The bytes to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified.
+    @inlinable
+    public mutating func check<Bytes: BytesCollection>(
+        _ bytes: Bytes,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) {
+        for byte in bytes {
+            try await check(byte)
+        }
+    }
+    
+    /// Asynchronously advances by the specified byte if found, throws if the next byte does not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a byte to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter byte: The byte to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent(
+        _ byte: UInt8,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) -> Bool {
+        let value: Element?
+        do {
+            value = try await next(isolation: actor)
+        } catch {
+            throw .iterationFailure(error)
+        }
+        guard let value else { return false }
+        if value != byte {
+            throw .consumptionFailure(.checkedSequenceNotFound)
+        }
+        
+        return true
+    }
+    
+    /// Asynchronously advances by the specified bytes if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a collection of bytes to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the bytes collection is an empty array, this method won't do anything.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter bytes: The bytes to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the bytes could not be identified.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Bytes: BytesCollection>(
+        _ bytes: Bytes,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) -> Bool {
         var first = true
         for byte in bytes {
             if first {

--- a/Sources/Bytes/AsyncChunkedBytes.swift
+++ b/Sources/Bytes/AsyncChunkedBytes.swift
@@ -78,12 +78,20 @@ extension AsyncChunkedBytes: AsyncSequence {
         
         /// Produces the next element in the chunked sequence.
         ///
-        /// This iterator buffers bytes up to `capacity`, then returnes then as a single chunk.
+        /// This iterator buffers bytes up to `capacity`, then returnes them as a single chunk.
         #if swift(>=6.2)
         @concurrent
         #endif
         @inlinable
         public mutating func next() async rethrows -> Bytes? {
+            try await baseIterator.nextIfPresent(Bytes.self, max: capacity)
+        }
+        
+        /// Produces the next element in the chunked sequence.
+        ///
+        /// This iterator buffers bytes up to `capacity`, then returnes them as a single chunk.
+        @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+        public mutating func next(isolation actor: isolated (any Actor)?) async throws(Base.Failure) -> Bytes? {
             try await baseIterator.nextIfPresent(Bytes.self, max: capacity)
         }
     }

--- a/Sources/Bytes/ByteIterator.swift
+++ b/Sources/Bytes/ByteIterator.swift
@@ -14,12 +14,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
         count: Int
-    ) throws -> Bytes {
+    ) throws(BytesError.BufferSizeError) -> Bytes {
         assert(count >= 0, "count must be larger than 0")
         return try next(bytes, min: count, max: count)
     }
@@ -31,13 +31,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) throws -> Bytes {
+    ) throws(BytesError.BufferSizeError) -> Bytes {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -54,7 +54,7 @@ extension IteratorProtocol where Element == Byte {
         }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .invalidBufferSize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
         }
         
         return result
@@ -94,12 +94,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         count: Int
-    ) throws -> Bytes? {
+    ) throws(BytesError.BufferSizeError) -> Bytes? {
         assert(count >= 0, "count must be larger than 0")
         return try nextIfPresent(bytes, min: count, max: count)
     }
@@ -111,13 +111,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) throws -> Bytes? {
+    ) throws(BytesError.BufferSizeError) -> Bytes? {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -136,7 +136,7 @@ extension IteratorProtocol where Element == Byte {
         guard !result.isEmpty else { return nil }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .invalidBufferSize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
         }
         
         return result
@@ -178,15 +178,15 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     public mutating func check(
         _ byte: UInt8
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         let value = next()
         
         guard value == byte
-        else { throw BytesError.checkedSequenceNotFound }
+        else { throw .checkedSequenceNotFound }
     }
     
     /// Advances by the specified bytes if found, or throws if the next bytes in the iterator do not match.
@@ -197,11 +197,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     public mutating func check<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         for byte in bytes {
             try check(byte)
         }
@@ -214,16 +214,16 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
     /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
         _ byte: UInt8
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         guard let value = next() else { return false }
         
         guard value == byte
-        else { throw BytesError.checkedSequenceNotFound }
+        else { throw .checkedSequenceNotFound }
         
         return true
     }
@@ -237,12 +237,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
     /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         var first = true
         for byte in bytes {
             if first {

--- a/Sources/Bytes/ByteIterator.swift
+++ b/Sources/Bytes/ByteIterator.swift
@@ -14,12 +14,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
         count: Int
-    ) throws -> Bytes {
+    ) throws(BytesError.InvalidMemorySize) -> Bytes {
         assert(count >= 0, "count must be larger than 0")
         return try next(bytes, min: count, max: count)
     }
@@ -31,13 +31,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) throws -> Bytes {
+    ) throws(BytesError.InvalidMemorySize) -> Bytes {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -54,7 +54,7 @@ extension IteratorProtocol where Element == Byte {
         }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
         }
         
         return result
@@ -94,12 +94,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter bytes: This should be set to `Bytes.self`.
     /// - Parameter count: The number of bytes to form into a byte array.
     /// - Returns: A byte array of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         count: Int
-    ) throws -> Bytes? {
+    ) throws(BytesError.InvalidMemorySize) -> Bytes? {
         assert(count >= 0, "count must be larger than 0")
         return try nextIfPresent(bytes, min: count, max: count)
     }
@@ -111,13 +111,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a byte array.
     /// - Parameter maxCount: The maximum number of bytes to form into a byte array.
     /// - Returns: A byte array of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: ``BytesError/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete byte array could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent(
         _ bytes: Bytes.Type,
         min minCount: Int,
         max maxCount: Int
-    ) throws -> Bytes? {
+    ) throws(BytesError.InvalidMemorySize) -> Bytes? {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
         precondition(minCount >= 0, "minCount must be larger than 0")
         guard maxCount > 0 else { return [] }
@@ -136,7 +136,7 @@ extension IteratorProtocol where Element == Byte {
         guard !result.isEmpty else { return nil }
         
         guard result.count >= minCount else {
-            throw BytesError.invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
+            throw .invalidMemorySize(targetSize: minCount, targetType: "\(Bytes.self)", actualSize: result.count)
         }
         
         return result
@@ -178,15 +178,15 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     public mutating func check(
         _ byte: UInt8
-    ) throws {
+    ) throws(BytesError.CheckedSequenceNotFound) {
         let value = next()
         
         guard value == byte
-        else { throw BytesError.checkedSequenceNotFound }
+        else { throw .checkedSequenceNotFound }
     }
     
     /// Advances by the specified bytes if found, or throws if the next bytes in the iterator do not match.
@@ -197,11 +197,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     public mutating func check<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) throws {
+    ) throws(BytesError.CheckedSequenceNotFound) {
         for byte in bytes {
             try check(byte)
         }
@@ -214,16 +214,16 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter byte: The byte to check for.
     /// - Returns: `true` if the byte was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
         _ byte: UInt8
-    ) throws -> Bool {
+    ) throws(BytesError.CheckedSequenceNotFound) -> Bool {
         guard let value = next() else { return false }
         
         guard value == byte
-        else { throw BytesError.checkedSequenceNotFound }
+        else { throw .checkedSequenceNotFound }
         
         return true
     }
@@ -237,12 +237,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter bytes: The bytes to check for.
     /// - Returns: `true` if the bytes were found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the bytes could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound/checkedSequenceNotFound`` if the bytes could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Bytes: BytesCollection>(
         _ bytes: Bytes
-    ) throws -> Bool {
+    ) throws(BytesError.CheckedSequenceNotFound) -> Bool {
         var first = true
         for byte in bytes {
             if first {

--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -9,7 +9,7 @@
 
 public typealias Byte = UInt8
 
-/// A type that has the same API as `Bytes`, `BytesSlice`, and `ContiguousBytes`.
+/// A type that has the same API as ``Bytes``, ``BytesSlice``, and ``ContiguousBytes``.
 public protocol BytesCollection: CustomDebugStringConvertible, CustomReflectable, CustomStringConvertible, ExpressibleByArrayLiteral, MutableCollection, RandomAccessCollection, RangeReplaceableCollection, Sendable where Element == Byte, Index == Int, SubSequence: BytesCollection {}
 
 public typealias Bytes = Array<Byte>

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -182,6 +182,19 @@ extension BytesError {
 extension BytesError.TransformationError: Equatable where TransformationFailure: Equatable {}
 extension BytesError.TransformationError: Hashable where TransformationFailure: Hashable {}
 
+extension BytesError.Transformation<BytesError.ContiguousBytes.BufferSizeError>.BufferSizeError {
+    /// Flatted a ``BytesError/TransformationError`` whose cases both contain a ``BytesError/BufferSizeError`` into a single ``BytesError/ContiguousBytes/BufferSizeError`` error.
+    @inlinable
+    public var flattened: BytesError.ContiguousBytes.BufferSizeError {
+        switch self {
+        case .castingFailure(let error):
+            .castingFailure(error)
+        case .transformationFailure(let error):
+            error
+        }
+    }
+}
+
 
 // MARK: - Bytes Error Type Alias Tree
 

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -17,3 +17,74 @@ public enum BytesError: Error {
     
     case checkedSequenceNotFound
 }
+
+public protocol ByteCastingError: Error, Equatable, Hashable {}
+
+
+extension BytesError {
+    /// An error thrown when the checked byte was not found as the next consumable element.
+    public struct CheckedSequenceNotFound: ByteCastingError {
+        /// An error thrown when the checked byte was not found as the next consumable element.
+        @inlinable
+        public init() {}
+    }
+    
+    /// An error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/Iteration`` error.
+    public typealias IteratedCheckedSequenceNotFound<Failure: Error> = Iteration<CheckedSequenceNotFound, Failure>
+}
+
+extension ByteCastingError where Self == BytesError.CheckedSequenceNotFound {
+    /// An error thrown when the checked byte was not found as the next consumable element.
+    @inlinable
+    public static var checkedSequenceNotFound: Self {
+        Self()
+    }
+}
+
+
+extension BytesError {
+    /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended.
+    public struct InvalidMemorySize: ByteCastingError {
+        /// The required size of the buffer.
+        public var targetSize: Int
+        /// The type that was being casted.
+        public var targetType: String
+        /// The actual available size of the buffer.
+        public var actualSize: Int
+        
+        @inlinable
+        public init(targetSize: Int, targetType: String, actualSize: Int) {
+            self.targetSize = targetSize
+            self.targetType = targetType
+            self.actualSize = actualSize
+        }
+    }
+    
+    /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/Iteration`` error.
+    public typealias IteratedInvalidMemorySize<Failure: Error> = Iteration<InvalidMemorySize, Failure>
+}
+
+extension ByteCastingError where Self == BytesError.InvalidMemorySize {
+    /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended.
+    @inlinable
+    public static func invalidMemorySize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
+        Self(targetSize: targetSize, targetType: targetType, actualSize: actualSize)
+    }
+}
+
+
+extension BytesError {
+    /// An error thrown when consuming a sequence.
+    public enum Iteration<
+        ConsumptionFailure: ByteCastingError,
+        IterationFailure: Error
+    >: Error {
+        /// An error was thrown consuming elements off the sequence.
+        case consumptionFailure(ConsumptionFailure)
+        /// An error was thrown by the underlying iterator.
+        case iterationFailure(IterationFailure)
+    }
+}
+
+extension BytesError.Iteration: Equatable where IterationFailure: Equatable {}
+extension BytesError.Iteration: Hashable where IterationFailure: Hashable {}

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -22,6 +22,45 @@ public protocol ByteCastingError: Error, Equatable, Hashable {}
 
 
 extension BytesError {
+    /// An error thrown while casting values to a given target type.
+    public enum Casting: ByteCastingError {
+        /// Consuming the sequence failed because an insufficient or invalid number of bytes were available before the sequence ended.
+        case invalidMemorySize(targetSize: Int, targetType: String, actualSize: Int)
+        /// Consuming the sequence failed because the underlying buffer is not contiguous and is over 4KB in size.
+        /// - Note: Copy the sequence first if you know the expected casting size is correct.
+        case contiguousMemoryUnavailable(type: String)
+        
+        @inlinable
+        public init(_ error: BytesError.InvalidMemorySize) {
+            self = .invalidMemorySize(targetSize: error.targetSize, targetType: error.targetType, actualSize: error.actualSize)
+        }
+    }
+    
+    /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/Iteration`` error.
+    public typealias IteratedCasting<Failure: Error> = Iteration<Casting, Failure>
+    /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/Transformation`` error.
+    public typealias TransformedCasting<Failure: Error> = Transformation<Casting, Failure>
+}
+
+extension ByteCastingError where Self == BytesError.Casting {
+    /// Consuming the sequence failed because an insufficient or invalid number of bytes were available before the sequence ended.
+    @inlinable
+    @_disfavoredOverload
+    public static func invalidMemorySize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
+        .invalidMemorySize(targetSize: targetSize, targetType: targetType, actualSize: actualSize)
+    }
+    
+    /// Consuming the sequence failed because the underlying buffer is not contiguous and is over 4KB in size.
+    /// - Note: Copy the sequence first if you know the expected casting size is correct.
+    @inlinable
+    @_disfavoredOverload
+    public static func contiguousMemoryUnavailable(type: String) -> Self {
+        .contiguousMemoryUnavailable(type: type)
+    }
+}
+
+
+extension BytesError {
     /// An error thrown when the checked byte was not found as the next consumable element.
     public struct CheckedSequenceNotFound: ByteCastingError {
         /// An error thrown when the checked byte was not found as the next consumable element.
@@ -31,6 +70,8 @@ extension BytesError {
     
     /// An error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/Iteration`` error.
     public typealias IteratedCheckedSequenceNotFound<Failure: Error> = Iteration<CheckedSequenceNotFound, Failure>
+    /// An error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/Transformation`` error.
+    public typealias TransformedCheckedSequenceNotFound<Failure: Error> = Transformation<CheckedSequenceNotFound, Failure>
 }
 
 extension ByteCastingError where Self == BytesError.CheckedSequenceNotFound {
@@ -62,6 +103,8 @@ extension BytesError {
     
     /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/Iteration`` error.
     public typealias IteratedInvalidMemorySize<Failure: Error> = Iteration<InvalidMemorySize, Failure>
+    /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/Transformation`` error.
+    public typealias TransformedInvalidMemorySize<Failure: Error> = Transformation<InvalidMemorySize, Failure>
 }
 
 extension ByteCastingError where Self == BytesError.InvalidMemorySize {
@@ -88,3 +131,20 @@ extension BytesError {
 
 extension BytesError.Iteration: Equatable where IterationFailure: Equatable {}
 extension BytesError.Iteration: Hashable where IterationFailure: Hashable {}
+
+
+extension BytesError {
+    /// An error thrown when consuming a sequence.
+    public enum Transformation<
+        ConsumptionFailure: ByteCastingError,
+        TransformationFailure: Error
+    >: Error {
+        /// An error was thrown consuming the sequence of bytes.
+        case consumptionFailure(ConsumptionFailure)
+        /// An error was thrown during transformation.
+        case transformationFailure(TransformationFailure)
+    }
+}
+
+extension BytesError.Transformation: Equatable where TransformationFailure: Equatable {}
+extension BytesError.Transformation: Hashable where TransformationFailure: Hashable {}

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -12,9 +12,6 @@
 
 public enum BytesError: Error {
     case invalidRawRepresentableByteSequence
-    case invalidUUIDByteSequence
-    
-    case checkedSequenceNotFound
 }
 
 
@@ -66,6 +63,18 @@ extension ByteCastingErrorWrapper where
 extension ByteCastingErrorWrapper where
     CastingFailure: ByteCastingErrorWrapper,
     CastingFailure.CastingFailure == BytesError.BufferSizeError
+{
+    /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended, wrapped in a parent error.
+    @inlinable
+    public static func invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
+        .castingFailure(.invalidBufferSize(targetSize: targetSize, targetType: targetType, actualSize: actualSize))
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure: ByteCastingErrorWrapper,
+    CastingFailure.CastingFailure: ByteCastingErrorWrapper,
+    CastingFailure.CastingFailure.CastingFailure == BytesError.BufferSizeError
 {
     /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended, wrapped in a parent error.
     @inlinable
@@ -143,6 +152,19 @@ extension ByteCastingErrorWrapper {
     }
 }
 
+extension ByteCastingErrorWrapper where
+    CastingFailure: ByteCastingErrorWrapper
+{
+    /// An error was thrown because the underlying buffer is not contiguous and is over 4KB in size, wrapped in a parent error.
+    /// - Note: Copy the sequence first if you know the expected casting size is correct.
+    @inlinable
+    public static func contiguousBytesUnavailable<InnerCastingFailure: ByteCastingError>(
+        type: String
+    ) -> Self where CastingFailure.CastingFailure == BytesError.ContiguousBytesError<InnerCastingFailure> {
+        .castingFailure(.contiguousBytesUnavailable(type: type))
+    }
+}
+
 
 // MARK: - IterationError
 
@@ -162,6 +184,17 @@ extension BytesError {
 extension BytesError.IterationError: Equatable where IterationFailure: Equatable {}
 extension BytesError.IterationError: Hashable where IterationFailure: Hashable {}
 
+extension BytesError.IterationError {
+    @inlinable
+    public func mapCastingFailure<NewCastingFailure: ByteCastingError>(
+        _ transform: (CastingFailure) -> NewCastingFailure
+    ) -> BytesError.IterationError<NewCastingFailure, IterationFailure> {
+        switch self {
+        case .castingFailure(let error):    .castingFailure(transform(error))
+        case .iterationFailure(let error):  .iterationFailure(error)
+        }
+    }
+}
 
 // MARK: - SequenceCheckError
 
@@ -213,16 +246,61 @@ extension BytesError {
 extension BytesError.TransformationError: Equatable where TransformationFailure: Equatable {}
 extension BytesError.TransformationError: Hashable where TransformationFailure: Hashable {}
 
-extension BytesError.Transformation<BytesError.ContiguousBytes.BufferSizeError>.BufferSizeError {
-    /// Flatted a ``BytesError/TransformationError`` whose cases both contain a ``BytesError/BufferSizeError`` into a single ``BytesError/ContiguousBytes/BufferSizeError`` error.
+extension BytesError.TransformationError {
     @inlinable
-    public var flattened: BytesError.ContiguousBytes.BufferSizeError {
+    public func mapCastingFailure<NewCastingFailure: ByteCastingError>(
+        _ transform: (CastingFailure) -> NewCastingFailure
+    ) -> BytesError.TransformationError<NewCastingFailure, TransformationFailure> {
+        switch self {
+        case .castingFailure(let error):        .castingFailure(transform(error))
+        case .transformationFailure(let error): .transformationFailure(error)
+        }
+    }
+}
+
+extension BytesError.TransformationError where
+    TransformationFailure: ByteCastingErrorWrapper,
+    TransformationFailure.CastingFailure == CastingFailure
+{
+    /// Flatten a ``BytesError/TransformationError`` whose cases both contain an identical leaf error into a single non-branching error.
+    @inlinable
+    public var flattened: TransformationFailure {
         switch self {
         case .castingFailure(let error):
             .castingFailure(error)
         case .transformationFailure(let error):
             error
         }
+    }
+}
+
+
+// MARK: - UUIDDecodingError
+
+extension BytesError {
+    /// An error thrown when a UUID could not be constructed from the byte sequence.
+    public enum UUIDDecodingError<CastingFailure: ByteCastingError>: ByteCastingError, ByteCastingErrorWrapper {
+        /// An error thrown while casting the specified bytes.
+        case castingFailure(CastingFailure)
+        /// An error thrown when a UUID could not be constructed from the byte sequence.
+        case invalidUUIDByteSequence
+    }
+}
+
+extension ByteCastingError {
+    /// An error thrown when a UUID could not be constructed from the byte sequence.
+    @inlinable
+    @_disfavoredOverload
+    public static func invalidUUIDByteSequence<CastingFailure: ByteCastingError>() -> BytesError.UUIDDecodingError<CastingFailure> {
+        .invalidUUIDByteSequence
+    }
+}
+
+extension ByteCastingErrorWrapper {
+    /// An error thrown when a UUID could not be constructed from the byte sequence, wrapped in a parent error.
+    @inlinable
+    public static func invalidUUIDByteSequence<InnerCastingFailure: ByteCastingError>() -> Self where CastingFailure == BytesError.UUIDDecodingError<InnerCastingFailure> {
+        .castingFailure(.invalidUUIDByteSequence())
     }
 }
 
@@ -255,6 +333,24 @@ extension BytesError {
         
         /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/IterationError``.
         public typealias SequenceCheckError = IterationError<BytesError.SequenceCheckError, IterationFailure>
+        
+        /// A ``BytesError/UUIDDecodingError`` error thrown when a UUID could not be constructed from the byte sequence, wrapped in a ``BytesError/IterationError``.
+        public typealias UUIDDecodingError<CastingFailure: ByteCastingError> = IterationError<BytesError.UUIDDecodingError<CastingFailure>, IterationFailure>
+        
+        /// A namespace for errors wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/IterationError`` respectively.
+        public enum UUIDDecoding {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/IterationError`` respectively.
+            public typealias BufferSizeError = UUIDDecodingError<BytesError.BufferSizeError>
+            
+            /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/IterationError``.
+            public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = UUIDDecodingError<BytesError.ContiguousBytesError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, and ``BytesError/IterationError`` respectively.
+            public enum ContiguousBytes {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, and ``BytesError/IterationError`` respectively.
+                public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+            }
+        }
     }
     
     /// A namespace for errors wrapped within a ``TransformationError``.
@@ -276,5 +372,38 @@ extension BytesError {
         
         /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/TransformationError``.
         public typealias SequenceCheckError = TransformationError<BytesError.SequenceCheckError, TransformationFailure>
+        
+        /// A ``BytesError/UUIDDecodingError`` error thrown when a UUID could not be constructed from the byte sequence, wrapped in a ``BytesError/TransformationError``.
+        public typealias UUIDDecodingError<CastingFailure: ByteCastingError> = TransformationError<BytesError.UUIDDecodingError<CastingFailure>, TransformationFailure>
+        
+        /// A namespace for errors wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/TransformationError`` respectively.
+        public enum UUIDDecoding {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/TransformationError`` respectively.
+            public typealias BufferSizeError = UUIDDecodingError<BytesError.BufferSizeError>
+            
+            /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/TransformationError``.
+            public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = UUIDDecodingError<BytesError.ContiguousBytesError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, and ``BytesError/TransformationError`` respectively.
+            public enum ContiguousBytes {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, and ``BytesError/TransformationError`` respectively.
+                public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+            }
+        }
+    }
+    
+    /// A namespace for errors wrapped within a ``BytesError/UUIDDecodingError``.
+    public enum UUIDDecoding {
+        /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/UUIDDecodingError`` respectively.
+        public typealias BufferSizeError = UUIDDecodingError<BytesError.BufferSizeError>
+        
+        /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped in a ``BytesError/UUIDDecodingError``.
+        public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = UUIDDecodingError<BytesError.ContiguousBytesError<CastingFailure>>
+        
+        /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/UUIDDecodingError`` respectively.
+        public enum ContiguousBytes {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/UUIDDecodingError`` respectively.
+            public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+        }
     }
 }

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -41,8 +41,12 @@ extension BytesError {
     public typealias RawRepresentableCasting = RawRepresentable<Casting>
     /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/Iteration`` error.
     public typealias IteratedCasting<Failure: Error> = Iteration<Casting, Failure>
+    /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/RawRepresentable`` error, itself wrapped in a ``BytesError/Iteration`` error.
+    public typealias IteratedRawRepresentableCasting<Failure: Error> = IteratedRawRepresentable<Failure, Casting>
     /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/Transformation`` error.
     public typealias TransformedCasting<Failure: Error> = Transformation<Casting, Failure>
+    /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/RawRepresentable`` error, itself wrapped in a ``BytesError/Transformation`` error.
+    public typealias TransformedRawRepresentableCasting<Failure: Error> = TransformedRawRepresentable<Failure, Casting>
 }
 
 extension ByteCastingError where Self == BytesError.Casting {

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -7,6 +7,9 @@
 //  mochidev-swift-bytes: F44D5591194F47C0834EC1EBD0102932
 //
 
+
+// MARK: - BytesError
+
 public enum BytesError: Error {
     case invalidMemorySize(targetSize: Int, targetType: String, actualSize: Int)
     case contiguousMemoryUnavailable(type: String)
@@ -16,4 +19,115 @@ public enum BytesError: Error {
     case invalidUUIDByteSequence
     
     case checkedSequenceNotFound
+}
+
+
+// MARK: - ByteCastingError
+
+public protocol ByteCastingError: Error, Equatable, Hashable {}
+extension Never: ByteCastingError {}
+
+public protocol ByteCastingErrorWrapper<CastingFailure>: Error {
+    associatedtype CastingFailure: ByteCastingError
+    static func castingFailure(_ castingFailure: CastingFailure) -> Self
+}
+
+
+// MARK: - BufferSizeError
+
+extension BytesError {
+    /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended.
+    public enum BufferSizeError: ByteCastingError {
+        /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended.
+        /// - Parameter targetSize: The required size of the buffer.
+        /// - Parameter targetType: The type that was being casted.
+        /// - Parameter actualSize: The actual available size of the buffer.
+        case invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int)
+    }
+}
+
+extension ByteCastingError where
+    Self == BytesError.BufferSizeError
+{
+    /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended.
+    @inlinable
+    @_disfavoredOverload
+    public static func invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
+        .invalidBufferSize(targetSize: targetSize, targetType: targetType, actualSize: actualSize)
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure == BytesError.BufferSizeError
+{
+    /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended, wrapped in a parent error.
+    @inlinable
+    public static func invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
+        .castingFailure(.invalidBufferSize(targetSize: targetSize, targetType: targetType, actualSize: actualSize))
+    }
+}
+
+
+// MARK: - IterationError
+
+extension BytesError {
+    /// An error thrown when consuming a sequence.
+    public enum IterationError<
+        CastingFailure: ByteCastingError,
+        IterationFailure: Error
+    >: Error, ByteCastingErrorWrapper {
+        /// An error was thrown casting bytes off the sequence.
+        case castingFailure(CastingFailure)
+        /// An error was thrown by the underlying iterator.
+        case iterationFailure(IterationFailure)
+    }
+}
+
+extension BytesError.IterationError: Equatable where IterationFailure: Equatable {}
+extension BytesError.IterationError: Hashable where IterationFailure: Hashable {}
+
+
+// MARK: - SequenceCheckError
+
+extension BytesError {
+    /// An error thrown when the checked byte was not found as the next consumable element.
+    public enum SequenceCheckError: ByteCastingError {
+        /// An error thrown when the checked byte was not found as the next consumable element.
+        case checkedSequenceNotFound
+    }
+}
+
+extension ByteCastingError where
+    Self == BytesError.SequenceCheckError
+{
+    /// An error thrown when the checked byte was not found as the next consumable element.
+    @inlinable
+    @_disfavoredOverload
+    public static var checkedSequenceNotFound: Self {
+        .checkedSequenceNotFound
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure == BytesError.SequenceCheckError
+{
+    /// An error thrown when the checked byte was not found as the next consumable element, wrapped in a parent error.
+    @inlinable
+    public static var checkedSequenceNotFound: Self {
+        .castingFailure(.checkedSequenceNotFound)
+    }
+}
+
+
+// MARK: - Bytes Error Type Alias Tree
+
+extension BytesError {
+    /// A namespace for errors wrapped within a ``IterationError``.
+    public enum Iteration<IterationFailure: Error> {
+        /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/IterationError``.
+        public typealias BufferSizeError = IterationError<BytesError.BufferSizeError, IterationFailure>
+                
+        /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/IterationError``.
+        public typealias SequenceCheckError = IterationError<BytesError.SequenceCheckError, IterationFailure>
+    }
 }

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -10,9 +10,7 @@
 
 // MARK: - BytesError
 
-public enum BytesError: Error {
-    case invalidRawRepresentableByteSequence
-}
+public enum BytesError: Error {}
 
 
 // MARK: - ByteCastingError
@@ -115,6 +113,17 @@ extension ByteCastingErrorWrapper where
     }
 }
 
+extension ByteCastingErrorWrapper where
+    CastingFailure: ByteCastingErrorWrapper,
+    CastingFailure.CastingFailure == BytesError.CharacterDecodingError
+{
+    /// An error thrown when the a character could not be constructed from the byte sequence, wrapped in a parent error.
+    @inlinable
+    public static var invalidCharacterByteSequence: Self {
+        .castingFailure(.invalidCharacterByteSequence)
+    }
+}
+
 
 // MARK: - ContiguousBytesError
 
@@ -196,6 +205,46 @@ extension BytesError.IterationError {
     }
 }
 
+// MARK: - RawRepresentableError
+
+extension BytesError {
+    /// An error thrown while initializing a `RawRepresentable` type with raw bytes.
+    public enum RawRepresentableError<CastingFailure: ByteCastingError>: ByteCastingError, ByteCastingErrorWrapper {
+        /// An error was thrown because the raw value could not be casted from the specified bytes.
+        case castingFailure(CastingFailure)
+        /// An error was thrown because the raw value evaluated to a `nil` `RawRepresentable` value.
+        case invalidRawRepresentableByteSequence(rawType: String)
+    }
+}
+
+extension ByteCastingError {
+    /// Consuming the sequence failed because the raw value evaluated to a `nil` `RawRepresentable` value.
+    @inlinable
+    @_disfavoredOverload
+    public static func invalidRawRepresentableByteSequence<CastingFailure: ByteCastingError>(rawType: String) -> BytesError.RawRepresentableError<CastingFailure> {
+        .invalidRawRepresentableByteSequence(rawType: rawType)
+    }
+}
+
+extension ByteCastingErrorWrapper {
+    /// Consuming the sequence failed because the raw value evaluated to a `nil` `RawRepresentable` value, wrapped in a parent error.
+    @inlinable
+    public static func invalidRawRepresentableByteSequence<InnerCastingFailure: ByteCastingError>(rawType: String) -> Self where CastingFailure == BytesError.RawRepresentableError<InnerCastingFailure> {
+        .castingFailure(.invalidRawRepresentableByteSequence(rawType: rawType))
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure: ByteCastingErrorWrapper
+{
+    /// Consuming the sequence failed because the raw value evaluated to a `nil` `RawRepresentable` value, wrapped in a parent error.
+    @inlinable
+    public static func invalidRawRepresentableByteSequence<InnerCastingFailure: ByteCastingError>(rawType: String) -> Self where CastingFailure.CastingFailure == BytesError.RawRepresentableError<InnerCastingFailure> {
+        .castingFailure(.invalidRawRepresentableByteSequence(rawType: rawType))
+    }
+}
+
+
 // MARK: - SequenceCheckError
 
 extension BytesError {
@@ -219,6 +268,17 @@ extension ByteCastingError where
 
 extension ByteCastingErrorWrapper where
     CastingFailure == BytesError.SequenceCheckError
+{
+    /// An error thrown when the checked byte was not found as the next consumable element, wrapped in a parent error.
+    @inlinable
+    public static var checkedSequenceNotFound: Self {
+        .castingFailure(.checkedSequenceNotFound)
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure: ByteCastingErrorWrapper,
+    CastingFailure.CastingFailure == BytesError.SequenceCheckError
 {
     /// An error thrown when the checked byte was not found as the next consumable element, wrapped in a parent error.
     @inlinable
@@ -274,6 +334,23 @@ extension BytesError.TransformationError where
     }
 }
 
+extension BytesError.TransformationError where
+    TransformationFailure: ByteCastingErrorWrapper,
+    TransformationFailure.CastingFailure: ByteCastingErrorWrapper,
+    TransformationFailure.CastingFailure.CastingFailure == CastingFailure
+{
+    /// Flatten a ``BytesError/TransformationError`` whose cases both contain an identical leaf error into a single non-branching error.
+    @inlinable
+    public var flattened: TransformationFailure {
+        switch self {
+        case .castingFailure(let error):
+            .castingFailure(.castingFailure(error))
+        case .transformationFailure(let error):
+            error
+        }
+    }
+}
+
 
 // MARK: - UUIDDecodingError
 
@@ -314,6 +391,45 @@ extension BytesError {
         public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
     }
     
+    /// A namespace for errors wrapped within a ``RawRepresentableError``.
+    public enum RawRepresentable {
+        /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/RawRepresentableError``.
+        public typealias BufferSizeError = RawRepresentableError<BytesError.BufferSizeError>
+        
+        /// A ``BytesError/CharacterDecodingError`` error thrown when the a character could not be constructed from the byte sequence, wrapped in a ``BytesError/RawRepresentableError``.
+        public typealias CharacterDecodingError = RawRepresentableError<BytesError.CharacterDecodingError>
+        
+        /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped in a ``BytesError/RawRepresentableError``.
+        public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = RawRepresentableError<BytesError.ContiguousBytesError<CastingFailure>>
+        
+        /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/RawRepresentableError`` respectively.
+        public enum ContiguousBytes {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/RawRepresentableError`` respectively.
+            public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+        }
+        
+        /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/RawRepresentableError``.
+        public typealias SequenceCheckError = RawRepresentableError<BytesError.SequenceCheckError>
+        
+        /// A ``BytesError/UUIDDecodingError`` error thrown when a UUID could not be constructed from the byte sequence, wrapped in a ``BytesError/RawRepresentableError``.
+        public typealias UUIDDecodingError<CastingFailure: ByteCastingError> = RawRepresentableError<BytesError.UUIDDecodingError<CastingFailure>>
+        
+        /// A namespace for errors wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/RawRepresentableError`` respectively.
+        public enum UUIDDecoding {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/RawRepresentableError`` respectively.
+            public typealias BufferSizeError = UUIDDecodingError<BytesError.BufferSizeError>
+            
+            /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped within ``BytesError/UUIDDecodingError`` and ``BytesError/RawRepresentableError``.
+            public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = UUIDDecodingError<BytesError.ContiguousBytesError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError`` and ``BytesError/RawRepresentableError`` respectively.
+            public enum ContiguousBytes {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, and ``BytesError/RawRepresentableError`` respectively.
+                public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+            }
+        }
+    }
+    
     /// A namespace for errors wrapped within a ``IterationError``.
     public enum Iteration<IterationFailure: Error> {
         /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/IterationError``.
@@ -329,6 +445,48 @@ extension BytesError {
         public enum ContiguousBytes {
             /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/IterationError`` respectively.
             public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+        }
+        
+        /// A ``BytesError/RawRepresentableError`` error thrown while initializing a `RawRepresentable` type with raw bytes, wrapped in a ``BytesError/IterationError``.
+        public typealias RawRepresentableError<CastingFailure: ByteCastingError> = IterationError<BytesError.RawRepresentableError<CastingFailure>, IterationFailure>
+        
+        /// A namespace for errors wrapped within ``BytesError/RawRepresentableError`` and ``BytesError/IterationError`` respectively.
+        public enum RawRepresentable {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, within ``BytesError/RawRepresentableError`` and ``BytesError/IterationError`` respectively.
+            public typealias BufferSizeError = RawRepresentableError<BytesError.BufferSizeError>
+            
+            /// A ``BytesError/CharacterDecodingError`` error thrown when the a character could not be constructed from the byte sequence, within ``BytesError/RawRepresentableError`` and ``BytesError/IterationError`` respectively.
+            public typealias CharacterDecodingError = RawRepresentableError<BytesError.CharacterDecodingError>
+            
+            /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, within ``BytesError/RawRepresentableError`` and ``BytesError/IterationError`` respectively.
+            public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = RawRepresentableError<BytesError.ContiguousBytesError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/RawRepresentableError`` respectively.
+            public enum ContiguousBytes {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/RawRepresentableError``, and ``BytesError/IterationError`` respectively.
+                public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+            }
+            
+            /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped within ``BytesError/RawRepresentableError`` and ``BytesError/IterationError`` respectively.
+            public typealias SequenceCheckError = RawRepresentableError<BytesError.SequenceCheckError>
+            
+            /// A ``BytesError/UUIDDecodingError`` error thrown when a UUID could not be constructed from the byte sequence, wrapped within ``BytesError/RawRepresentableError`` and ``BytesError/IterationError`` respectively.
+            public typealias UUIDDecodingError<CastingFailure: ByteCastingError> = RawRepresentableError<BytesError.UUIDDecodingError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/IterationError`` respectively.
+            public enum UUIDDecoding {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/IterationError`` respectively.
+                public typealias BufferSizeError = UUIDDecodingError<BytesError.BufferSizeError>
+                
+                /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped within ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/IterationError``.
+                public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = UUIDDecodingError<BytesError.ContiguousBytesError<CastingFailure>>
+                
+                /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/IterationError`` respectively.
+                public enum ContiguousBytes {
+                    /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/IterationError`` respectively.
+                    public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+                }
+            }
         }
         
         /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/IterationError``.
@@ -368,6 +526,48 @@ extension BytesError {
         public enum ContiguousBytes {
             /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/TransformationError`` respectively.
             public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+        }
+        
+        /// A ``BytesError/RawRepresentableError`` error thrown while initializing a `RawRepresentable` type with raw bytes, wrapped in a ``BytesError/TransformationError``.
+        public typealias RawRepresentableError<CastingFailure: ByteCastingError> = TransformationError<BytesError.RawRepresentableError<CastingFailure>, TransformationFailure>
+        
+        /// A namespace for errors wrapped within ``BytesError/RawRepresentableError`` and ``BytesError/TransformationError`` respectively.
+        public enum RawRepresentable {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, within ``BytesError/RawRepresentableError`` and ``BytesError/TransformationError`` respectively.
+            public typealias BufferSizeError = RawRepresentableError<BytesError.BufferSizeError>
+            
+            /// A ``BytesError/CharacterDecodingError`` error thrown when the a character could not be constructed from the byte sequence, within ``BytesError/RawRepresentableError`` and ``BytesError/TransformationError`` respectively.
+            public typealias CharacterDecodingError = RawRepresentableError<BytesError.CharacterDecodingError>
+            
+            /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, within ``BytesError/RawRepresentableError`` and ``BytesError/TransformationError`` respectively.
+            public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = RawRepresentableError<BytesError.ContiguousBytesError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/RawRepresentableError`` respectively.
+            public enum ContiguousBytes {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/RawRepresentableError``, and ``BytesError/TransformationError`` respectively.
+                public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+            }
+            
+            /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped within ``BytesError/RawRepresentableError`` and ``BytesError/TransformationError`` respectively.
+            public typealias SequenceCheckError = RawRepresentableError<BytesError.SequenceCheckError>
+            
+            /// A ``BytesError/UUIDDecodingError`` error thrown when a UUID could not be constructed from the byte sequence, wrapped within ``BytesError/RawRepresentableError`` and ``BytesError/TransformationError`` respectively.
+            public typealias UUIDDecodingError<CastingFailure: ByteCastingError> = RawRepresentableError<BytesError.UUIDDecodingError<CastingFailure>>
+            
+            /// A namespace for errors wrapped within ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/TransformationError`` respectively.
+            public enum UUIDDecoding {
+                /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/TransformationError`` respectively.
+                public typealias BufferSizeError = UUIDDecodingError<BytesError.BufferSizeError>
+                
+                /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped within ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/TransformationError``.
+                public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = UUIDDecodingError<BytesError.ContiguousBytesError<CastingFailure>>
+                
+                /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/TransformationError`` respectively.
+                public enum ContiguousBytes {
+                    /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError``, ``BytesError/UUIDDecodingError``, ``BytesError/RawRepresentableError``, and ``BytesError/TransformationError`` respectively.
+                    public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+                }
+            }
         }
         
         /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/TransformationError``.

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -107,6 +107,18 @@ extension BytesError {
     public typealias TransformedInvalidMemorySize<Failure: Error> = Transformation<InvalidMemorySize, Failure>
 }
 
+extension BytesError.TransformedInvalidMemorySize<BytesError.Casting> {
+    @inlinable
+    public var flattened: BytesError.Casting {
+        switch self {
+        case .consumptionFailure(let error):
+            .init(error)
+        case .transformationFailure(let error):
+            error
+        }
+    }
+}
+
 extension ByteCastingError where Self == BytesError.InvalidMemorySize {
     /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended.
     @inlinable

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -11,7 +11,6 @@
 // MARK: - BytesError
 
 public enum BytesError: Error {
-    case invalidCharacterByteSequence
     case invalidRawRepresentableByteSequence
     case invalidUUIDByteSequence
     
@@ -72,6 +71,38 @@ extension ByteCastingErrorWrapper where
     @inlinable
     public static func invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
         .castingFailure(.invalidBufferSize(targetSize: targetSize, targetType: targetType, actualSize: actualSize))
+    }
+}
+
+
+// MARK: - CharacterDecodingError
+
+extension BytesError {
+    /// An error thrown when a character could not be constructed from the byte sequence.
+    public enum CharacterDecodingError: ByteCastingError {
+        /// An error thrown when a character could not be constructed from the byte sequence.
+        case invalidCharacterByteSequence
+    }
+}
+
+extension ByteCastingError where
+    Self == BytesError.CharacterDecodingError
+{
+    /// An error thrown when a character could not be constructed from the byte sequence.
+    @inlinable
+    @_disfavoredOverload
+    public static var invalidCharacterByteSequence: Self {
+        .invalidCharacterByteSequence
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure == BytesError.CharacterDecodingError
+{
+    /// An error thrown when a character could not be constructed from the byte sequence, wrapped in a parent error.
+    @inlinable
+    public static var invalidCharacterByteSequence: Self {
+        .castingFailure(.invalidCharacterByteSequence)
     }
 }
 
@@ -210,6 +241,9 @@ extension BytesError {
         /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/IterationError``.
         public typealias BufferSizeError = IterationError<BytesError.BufferSizeError, IterationFailure>
         
+        /// A ``BytesError/CharacterDecodingError`` error thrown when a character could not be constructed from the byte sequence, wrapped in a ``BytesError/IterationError``.
+        public typealias CharacterDecodingError = IterationError<BytesError.CharacterDecodingError, IterationFailure>
+        
         /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped in a ``BytesError/IterationError``.
         public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = IterationError<BytesError.ContiguousBytesError<CastingFailure>, IterationFailure>
         
@@ -227,6 +261,9 @@ extension BytesError {
     public enum Transformation<TransformationFailure: Error> {
         /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/TransformationError``.
         public typealias BufferSizeError = TransformationError<BytesError.BufferSizeError, TransformationFailure>
+        
+        /// A ``BytesError/CharacterDecodingError`` error thrown when a character could not be constructed from the byte sequence, wrapped in a ``BytesError/TransformationError``.
+        public typealias CharacterDecodingError = TransformationError<BytesError.CharacterDecodingError, TransformationFailure>
         
         /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped in a ``BytesError/TransformationError``.
         public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = TransformationError<BytesError.ContiguousBytesError<CastingFailure>, TransformationFailure>

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -19,6 +19,7 @@ public enum BytesError: Error {
 }
 
 public protocol ByteCastingError: Error, Equatable, Hashable {}
+extension Never: ByteCastingError {}
 
 
 extension BytesError {
@@ -36,6 +37,8 @@ extension BytesError {
         }
     }
     
+    /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/RawRepresentable`` error.
+    public typealias RawRepresentableCasting = RawRepresentable<Casting>
     /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/Iteration`` error.
     public typealias IteratedCasting<Failure: Error> = Iteration<Casting, Failure>
     /// An error thrown while casting values to a given target type, wrapped in a ``BytesError/Transformation`` error.
@@ -90,6 +93,9 @@ extension BytesError {
         @inlinable
         public init() {}
     }
+    
+    /// An error thrown when the a character could not be constructed from the byte sequence, wrapped in a ``BytesError/RawRepresentable`` error.
+    public typealias RawRepresentableCharacter = RawRepresentable<Character>
 }
 
 extension ByteCastingError where Self == BytesError.Character {
@@ -142,6 +148,31 @@ extension ByteCastingError where Self == BytesError.InvalidMemorySize {
     @inlinable
     public static func invalidMemorySize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
         Self(targetSize: targetSize, targetType: targetType, actualSize: actualSize)
+    }
+}
+
+
+extension BytesError {
+    /// An error thrown while initializing a `RawRepresentable` type with raw bytes.
+    public enum RawRepresentable<CastingFailure: ByteCastingError>: ByteCastingError {
+        /// Consuming the sequence failed because the raw value could not be casted from the specified byte sequence.
+        case castingFailure(CastingFailure)
+        /// Consuming the sequence failed because the raw value evaluated to a `nil` `RawRepresentable` value.
+        case invalidRawRepresentableByteSequence(rawType: String)
+    }
+    
+    /// An error thrown while initializing a `RawRepresentable` type with raw bytes, wrapped in a ``BytesError/Iteration`` error.
+    public typealias IteratedRawRepresentable<Failure: Error, CastingFailure: ByteCastingError> = Iteration<RawRepresentable<CastingFailure>, Failure>
+    /// An error thrown while initializing a `RawRepresentable` type with raw bytes, wrapped in a ``BytesError/Transformation`` error.
+    public typealias TransformedRawRepresentable<Failure: Error, CastingFailure: ByteCastingError> = Transformation<RawRepresentable<CastingFailure>, Failure>
+}
+
+extension ByteCastingError where Self == BytesError.RawRepresentable<Never> {
+    /// Consuming the sequence failed because the raw value evaluated to a `nil` `RawRepresentable` value.
+    @inlinable
+    @_disfavoredOverload
+    public static func invalidRawRepresentableByteSequence(rawType: String) -> Self {
+        .invalidRawRepresentableByteSequence(rawType: rawType)
     }
 }
 

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -84,6 +84,24 @@ extension ByteCastingError where Self == BytesError.CheckedSequenceNotFound {
 
 
 extension BytesError {
+    /// An error thrown when the a character could not be constructed from the byte sequence.
+    public struct Character: ByteCastingError {
+        /// An error thrown when the a character could not be constructed from the byte sequence.
+        @inlinable
+        public init() {}
+    }
+}
+
+extension ByteCastingError where Self == BytesError.Character {
+    /// An error thrown when the a character could not be constructed from the byte sequence.
+    @inlinable
+    public static var invalidCharacterByteSequence: Self {
+        Self()
+    }
+}
+
+
+extension BytesError {
     /// An error thrown when an insufficient or invalid number of bytes were available before the sequence ended.
     public struct InvalidMemorySize: ByteCastingError {
         /// The required size of the buffer.

--- a/Sources/Bytes/BytesError.swift
+++ b/Sources/Bytes/BytesError.swift
@@ -11,9 +11,6 @@
 // MARK: - BytesError
 
 public enum BytesError: Error {
-    case invalidMemorySize(targetSize: Int, targetType: String, actualSize: Int)
-    case contiguousMemoryUnavailable(type: String)
-    
     case invalidCharacterByteSequence
     case invalidRawRepresentableByteSequence
     case invalidUUIDByteSequence
@@ -64,6 +61,54 @@ extension ByteCastingErrorWrapper where
     @inlinable
     public static func invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
         .castingFailure(.invalidBufferSize(targetSize: targetSize, targetType: targetType, actualSize: actualSize))
+    }
+}
+
+extension ByteCastingErrorWrapper where
+    CastingFailure: ByteCastingErrorWrapper,
+    CastingFailure.CastingFailure == BytesError.BufferSizeError
+{
+    /// An error thrown when an insufficient or invalid number of bytes were available before the ``Bytes`` sequence ended, wrapped in a parent error.
+    @inlinable
+    public static func invalidBufferSize(targetSize: Int, targetType: String, actualSize: Int) -> Self {
+        .castingFailure(.invalidBufferSize(targetSize: targetSize, targetType: targetType, actualSize: actualSize))
+    }
+}
+
+
+// MARK: - ContiguousBytesError
+
+extension BytesError {
+    /// An error thrown when the receiving buffer cannot efficiently be made contiguous for casting.
+    public enum ContiguousBytesError<CastingFailure: ByteCastingError>: ByteCastingError, ByteCastingErrorWrapper {
+        /// An error thrown while casting the specified bytes.
+        case castingFailure(CastingFailure)
+        /// An error was thrown because the underlying buffer is not contiguous and is over 4KB in size.
+        /// - Note: Copy the sequence first if you know the expected casting size is correct.
+        case contiguousBytesUnavailable(type: String)
+    }
+}
+
+extension ByteCastingError {
+    /// An error was thrown because the underlying buffer is not contiguous and is over 4KB in size.
+    /// - Note: Copy the sequence first if you know the expected casting size is correct.
+    @inlinable
+    @_disfavoredOverload
+    public static func contiguousBytesUnavailable<CastingFailure: ByteCastingError>(
+        type: String
+    ) -> BytesError.ContiguousBytesError<CastingFailure> {
+        .contiguousBytesUnavailable(type: type)
+    }
+}
+
+extension ByteCastingErrorWrapper {
+    /// An error was thrown because the underlying buffer is not contiguous and is over 4KB in size, wrapped in a parent error.
+    /// - Note: Copy the sequence first if you know the expected casting size is correct.
+    @inlinable
+    public static func contiguousBytesUnavailable<InnerCastingFailure: ByteCastingError>(
+        type: String
+    ) -> Self where CastingFailure == BytesError.ContiguousBytesError<InnerCastingFailure> {
+        .castingFailure(.contiguousBytesUnavailable(type: type))
     }
 }
 
@@ -119,15 +164,67 @@ extension ByteCastingErrorWrapper where
 }
 
 
+// MARK: - TransformationError
+
+extension BytesError {
+    /// An error thrown when consuming a sequence.
+    public enum TransformationError<
+        CastingFailure: ByteCastingError,
+        TransformationFailure: Error
+    >: Error, ByteCastingErrorWrapper {
+        /// An error was thrown casting bytes off the sequence.
+        case castingFailure(CastingFailure)
+        /// An error was thrown during transformation.
+        case transformationFailure(TransformationFailure)
+    }
+}
+
+extension BytesError.TransformationError: Equatable where TransformationFailure: Equatable {}
+extension BytesError.TransformationError: Hashable where TransformationFailure: Hashable {}
+
+
 // MARK: - Bytes Error Type Alias Tree
 
 extension BytesError {
+    /// A namespace for errors wrapped within a ``ContiguousBytesError``.
+    public enum ContiguousBytes {
+        /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/ContiguousBytesError``.
+        public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+    }
+    
     /// A namespace for errors wrapped within a ``IterationError``.
     public enum Iteration<IterationFailure: Error> {
         /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/IterationError``.
         public typealias BufferSizeError = IterationError<BytesError.BufferSizeError, IterationFailure>
-                
+        
+        /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped in a ``BytesError/IterationError``.
+        public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = IterationError<BytesError.ContiguousBytesError<CastingFailure>, IterationFailure>
+        
+        /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/IterationError`` respectively.
+        public enum ContiguousBytes {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/IterationError`` respectively.
+            public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+        }
+        
         /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/IterationError``.
         public typealias SequenceCheckError = IterationError<BytesError.SequenceCheckError, IterationFailure>
+    }
+    
+    /// A namespace for errors wrapped within a ``TransformationError``.
+    public enum Transformation<TransformationFailure: Error> {
+        /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped in a ``BytesError/TransformationError``.
+        public typealias BufferSizeError = TransformationError<BytesError.BufferSizeError, TransformationFailure>
+        
+        /// A ``BytesError/ContiguousBytesError`` error thrown when the receiving buffer cannot efficiently be made contiguous for casting, wrapped in a ``BytesError/TransformationError``.
+        public typealias ContiguousBytesError<CastingFailure: ByteCastingError> = TransformationError<BytesError.ContiguousBytesError<CastingFailure>, TransformationFailure>
+        
+        /// A namespace for errors wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/TransformationError`` respectively.
+        public enum ContiguousBytes {
+            /// A ``BytesError/BufferSizeError`` error thrown when an insufficient or invalid number of bytes were available before the sequence ended, wrapped within ``BytesError/ContiguousBytesError`` and ``BytesError/TransformationError`` respectively.
+            public typealias BufferSizeError = ContiguousBytesError<BytesError.BufferSizeError>
+        }
+        
+        /// A ``BytesError/SequenceCheckError`` error thrown when the checked byte was not found as the next consumable element, wrapped in a ``BytesError/TransformationError``.
+        public typealias SequenceCheckError = TransformationError<BytesError.SequenceCheckError, TransformationFailure>
     }
 }

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -18,24 +18,15 @@ extension Collection where Element == Byte {
         }
     }
     
-    /// Cast an _entire_ ``Bytes`` sequence to the target's type.
-    /// - Parameter target: The type of the target.
-    /// - Throws:
-    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
-    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
-    /// - Returns: An instance of the target represented by the ``Bytes`` sequence.
-    @inlinable
-    public func casting<R>(to target: R.Type) throws(BytesError.ContiguousBytes.BufferSizeError) -> R {
-        try casting()
-    }
-    
     /// Cast an _entire_ ``Bytes`` sequence to the lhs's type.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
     ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
     /// - Returns: An instance represented by the ``Bytes`` sequence.
     @inlinable
-    public func casting<R>() throws(BytesError.ContiguousBytes.BufferSizeError) -> R {
+    public func casting<R>(
+        to target: R.Type = R.self
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) -> R {
         do {
             try canBeCasted(to: R.self)
         } catch {

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -8,35 +8,39 @@
 //
 
 extension Collection where Element == Byte {
-    /// Check if a sequence of Bytes can be safely casted to an element.
+    /// Check if a sequence of ``Bytes`` can be safely casted to an element.
     /// - Parameter target: The type of element to cast to.
-    /// - Throws: `BytesError.invalidMemorySize` if the size of the bytes sequence is not equal to the element's size.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if the size of the bytes sequence is not equal to the element's size.
     @inlinable
-    func canBeCasted<Element>(to target: Element.Type) throws {
+    func canBeCasted<Element>(to target: Element.Type) throws(BytesError.InvalidMemorySize) {
         guard MemoryLayout<Element>.size == self.count else {
-            throw BytesError.invalidMemorySize(targetSize: MemoryLayout<Element>.size, targetType: "\(Element.self)", actualSize: self.count)
+            throw .invalidMemorySize(targetSize: MemoryLayout<Element>.size, targetType: "\(Element.self)", actualSize: self.count)
         }
     }
     
-    /// Cast an _entire_ Bytes sequence to the target's type.
+    /// Cast an _entire_ ``Bytes`` sequence to the target's type.
     /// - Parameter target: The type of the target.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the memory layout of the bytes sequence does not match the desired type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if contiguous memory could not be made available.
-    /// - Returns: An instance of the target represented by the Bytes sequence.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the memory layout of the bytes sequence does not match the desired type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
+    /// - Returns: An instance of the target represented by the ``Bytes`` sequence.
     @inlinable
-    public func casting<R>(to target: R.Type) throws -> R {
+    public func casting<R>(to target: R.Type) throws(BytesError.Casting) -> R {
         try casting()
     }
     
-    /// Cast an _entire_ Bytes sequence to the lhs's type.
+    /// Cast an _entire_ ``Bytes`` sequence to the lhs's type.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the memory layout of the bytes sequence does not match the desired type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if contiguous memory could not be made available.
-    /// - Returns: An instance represented by the Bytes sequence.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the memory layout of the bytes sequence does not match the desired type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
+    /// - Returns: An instance represented by the ``Bytes`` sequence.
     @inlinable
-    public func casting<R>() throws -> R {
-        try canBeCasted(to: R.self)
+    public func casting<R>() throws(BytesError.Casting) -> R {
+        do {
+            try canBeCasted(to: R.self)
+        } catch {
+            throw .init(error)
+        }
         
         if let result = self.withContiguousStorageIfAvailable({
             UnsafeRawBufferPointer($0).loadUnaligned(as: R.self)
@@ -46,30 +50,30 @@ extension Collection where Element == Byte {
         
         /// If bytes is less than 4KB, then perform a copy first
         guard self.count <= 4*1024
-        else { throw BytesError.contiguousMemoryUnavailable(type: "\(Self.self)") }
+        else { throw .contiguousMemoryUnavailable(type: "\(Self.self)") }
         
         return Bytes(self).withUnsafeBytes { $0.loadUnaligned(as: R.self) }
     }
     
-    /// Create a new Bytes sequence from the memory occupied by the passed in value.
+    /// Create a new ``Bytes`` sequence from the memory occupied by the passed in value.
     /// - Parameter value: The value to cast to a sequence of bytes.
     @inlinable
     public init<T>(casting value: T) where Self: RangeReplaceableCollection {
         self = withUnsafeBytes(of: value) { Self($0) }
     }
     
-    /// Check if a sequence of Bytes can be safely mapped to a collection of elements.
+    /// Check if a sequence of ``Bytes`` can be safely mapped to a collection of elements.
     /// - Parameter target: The type of element to map to.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     /// - Returns: `(elementSize: Int, numberOfBytes: Int, elementCount: Int)`, to aid in building the new collection.
     @inlinable
-    func canBeMapped<Element>(to target: Element.Type) throws -> (elementSize: Int, numberOfBytes: Int, elementCount: Int) {
+    func canBeMapped<Element>(to target: Element.Type) throws(BytesError.InvalidMemorySize) -> (elementSize: Int, numberOfBytes: Int, elementCount: Int) {
         let elementSize = MemoryLayout<Element>.size
         let numberOfBytes = self.count
         let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: elementSize)
         
         guard remainingElementSize == 0 else {
-            throw BytesError.invalidMemorySize(targetSize: (elementCount+1)*elementSize, targetType: "\(Element.self)", actualSize: numberOfBytes)
+            throw .invalidMemorySize(targetSize: (elementCount+1)*elementSize, targetType: "\(Element.self)", actualSize: numberOfBytes)
         }
         
         return (elementSize, numberOfBytes, elementCount)
@@ -77,19 +81,19 @@ extension Collection where Element == Byte {
 }
 
 extension Collection {
-    /// Create a new Bytes sequence mapping each element accordingly.
+    /// Create a new ``Bytes`` sequence mapping each element accordingly.
     /// - Parameter transform: The transformation to perform on each element.
-    /// - Returns: A Bytes sequence.
+    /// - Returns: A ``Bytes`` sequence.
     @inlinable
     public func bytes(mapping transform: (Self.Element) -> Bytes) -> Bytes {
         bytes(for: Element.self, mapping: transform)
     }
     
-    /// Create a new Bytes sequence mapping each element accordingly.
+    /// Create a new ``Bytes`` sequence mapping each element accordingly.
     /// - Parameters:
     ///   - target: The element that was used to encode the byte sequence.
     ///   - transform: The transformation to perform on each element.
-    /// - Returns: A Bytes sequence.
+    /// - Returns: A ``Bytes`` sequence.
     @inlinable
     public func bytes<EncodedElement>(for target: EncodedElement.Type, mapping transform: (Self.Element) -> Bytes) -> Bytes {
         var bytes = Bytes()
@@ -106,9 +110,9 @@ extension RangeReplaceableCollection {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
+    public init<Bytes: BytesCollection, TransformationFailure: Error>(bytes: Bytes, mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element) throws(BytesError.TransformedInvalidMemorySize<TransformationFailure>) {
         try self.init(bytes: bytes, element: Element.self, mapping: transform)
     }
     
@@ -117,17 +121,36 @@ extension RangeReplaceableCollection {
     ///   - bytes: The bytes to transform.
     ///   - element: The element that was used to encode the byte sequence.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     @inlinable
-    public init<Bytes: BytesCollection, EncodedElement>(bytes: Bytes, element: EncodedElement.Type, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
-        let (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+    public init<
+        Bytes: BytesCollection,
+        EncodedElement,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        element: EncodedElement.Type,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.TransformedInvalidMemorySize<TransformationFailure>) {
+        let elementSize: Int
+        let numberOfBytes: Int
+        let elementCount: Int
+        do {
+            (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+        } catch {
+            throw .consumptionFailure(error)
+        }
         
         var result = Self()
         result.reserveCapacity(elementCount)
         
         for sliceStart in stride(from: 0, to: numberOfBytes, by: elementSize) {
             let slice = bytes[sliceStart..<(sliceStart+elementSize)]
-            result.append(try transform(slice))
+            do {
+                result.append(try transform(slice))
+            } catch {
+                throw .transformationFailure(error)
+            }
         }
         
         self = result
@@ -139,9 +162,15 @@ extension Set {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
+    public init<
+        Bytes: BytesCollection,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.TransformedInvalidMemorySize<TransformationFailure>) {
         try self.init(bytes: bytes, element: Element.self, mapping: transform)
     }
     
@@ -150,17 +179,36 @@ extension Set {
     ///   - bytes: The bytes to transform.
     ///   - element: The element that was used to encode the byte sequence.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     @inlinable
-    public init<Bytes: BytesCollection, EncodedElement>(bytes: Bytes, element: EncodedElement.Type, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
-        let (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+    public init<
+        Bytes: BytesCollection,
+        EncodedElement,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        element: EncodedElement.Type,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.TransformedInvalidMemorySize<TransformationFailure>) {
+        let elementSize: Int
+        let numberOfBytes: Int
+        let elementCount: Int
+        do {
+            (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+        } catch {
+            throw .consumptionFailure(error)
+        }
         
         var result = Self()
         result.reserveCapacity(elementCount)
         
         for sliceStart in stride(from: 0, to: numberOfBytes, by: elementSize) {
             let slice = bytes[sliceStart..<(sliceStart+elementSize)]
-            result.insert(try transform(slice))
+            do {
+                result.insert(try transform(slice))
+            } catch {
+                throw .transformationFailure(error)
+            }
         }
         
         self = result

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -8,35 +8,39 @@
 //
 
 extension Collection where Element == Byte {
-    /// Check if a sequence of Bytes can be safely casted to an element.
+    /// Check if a sequence of ``Bytes`` can be safely casted to an element.
     /// - Parameter target: The type of element to cast to.
-    /// - Throws: `BytesError.invalidMemorySize` if the size of the bytes sequence is not equal to the element's size.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the size of the bytes sequence is not equal to the element's size.
     @inlinable
-    func canBeCasted<Element>(to target: Element.Type) throws {
+    func canBeCasted<Element>(to target: Element.Type) throws(BytesError.BufferSizeError) {
         guard MemoryLayout<Element>.size == self.count else {
-            throw BytesError.invalidMemorySize(targetSize: MemoryLayout<Element>.size, targetType: "\(Element.self)", actualSize: self.count)
+            throw .invalidBufferSize(targetSize: MemoryLayout<Element>.size, targetType: "\(Element.self)", actualSize: self.count)
         }
     }
     
-    /// Cast an _entire_ Bytes sequence to the target's type.
+    /// Cast an _entire_ ``Bytes`` sequence to the target's type.
     /// - Parameter target: The type of the target.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the memory layout of the bytes sequence does not match the desired type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if contiguous memory could not be made available.
-    /// - Returns: An instance of the target represented by the Bytes sequence.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
+    /// - Returns: An instance of the target represented by the ``Bytes`` sequence.
     @inlinable
-    public func casting<R>(to target: R.Type) throws -> R {
+    public func casting<R>(to target: R.Type) throws(BytesError.ContiguousBytes.BufferSizeError) -> R {
         try casting()
     }
     
-    /// Cast an _entire_ Bytes sequence to the lhs's type.
+    /// Cast an _entire_ ``Bytes`` sequence to the lhs's type.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the memory layout of the bytes sequence does not match the desired type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if contiguous memory could not be made available.
-    /// - Returns: An instance represented by the Bytes sequence.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
+    /// - Returns: An instance represented by the ``Bytes`` sequence.
     @inlinable
-    public func casting<R>() throws -> R {
-        try canBeCasted(to: R.self)
+    public func casting<R>() throws(BytesError.ContiguousBytes.BufferSizeError) -> R {
+        do {
+            try canBeCasted(to: R.self)
+        } catch {
+            throw .castingFailure(error)
+        }
         
         if let result = self.withContiguousStorageIfAvailable({
             UnsafeRawBufferPointer($0).loadUnaligned(as: R.self)
@@ -46,30 +50,32 @@ extension Collection where Element == Byte {
         
         /// If bytes is less than 4KB, then perform a copy first
         guard self.count <= 4*1024
-        else { throw BytesError.contiguousMemoryUnavailable(type: "\(Self.self)") }
+        else { throw .contiguousBytesUnavailable(type: "\(Self.self)") }
         
         return Bytes(self).withUnsafeBytes { $0.loadUnaligned(as: R.self) }
     }
     
-    /// Create a new Bytes sequence from the memory occupied by the passed in value.
+    /// Create a new ``Bytes`` sequence from the memory occupied by the passed in value.
     /// - Parameter value: The value to cast to a sequence of bytes.
     @inlinable
     public init<T>(casting value: T) where Self: RangeReplaceableCollection {
         self = withUnsafeBytes(of: value) { Self($0) }
     }
     
-    /// Check if a sequence of Bytes can be safely mapped to a collection of elements.
+    /// Check if a sequence of ``Bytes`` can be safely mapped to a collection of elements.
     /// - Parameter target: The type of element to map to.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     /// - Returns: `(elementSize: Int, numberOfBytes: Int, elementCount: Int)`, to aid in building the new collection.
     @inlinable
-    func canBeMapped<Element>(to target: Element.Type) throws -> (elementSize: Int, numberOfBytes: Int, elementCount: Int) {
+    func canBeMapped<Element>(
+        to target: Element.Type
+    ) throws(BytesError.BufferSizeError) -> (elementSize: Int, numberOfBytes: Int, elementCount: Int) {
         let elementSize = MemoryLayout<Element>.size
         let numberOfBytes = self.count
         let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: elementSize)
         
         guard remainingElementSize == 0 else {
-            throw BytesError.invalidMemorySize(targetSize: (elementCount+1)*elementSize, targetType: "\(Element.self)", actualSize: numberOfBytes)
+            throw .invalidBufferSize(targetSize: (elementCount+1)*elementSize, targetType: "\(Element.self)", actualSize: numberOfBytes)
         }
         
         return (elementSize, numberOfBytes, elementCount)
@@ -77,19 +83,19 @@ extension Collection where Element == Byte {
 }
 
 extension Collection {
-    /// Create a new Bytes sequence mapping each element accordingly.
+    /// Create a new ``Bytes`` sequence mapping each element accordingly.
     /// - Parameter transform: The transformation to perform on each element.
-    /// - Returns: A Bytes sequence.
+    /// - Returns: A ``Bytes`` sequence.
     @inlinable
     public func bytes(mapping transform: (Self.Element) -> Bytes) -> Bytes {
         bytes(for: Element.self, mapping: transform)
     }
     
-    /// Create a new Bytes sequence mapping each element accordingly.
+    /// Create a new ``Bytes`` sequence mapping each element accordingly.
     /// - Parameters:
     ///   - target: The element that was used to encode the byte sequence.
     ///   - transform: The transformation to perform on each element.
-    /// - Returns: A Bytes sequence.
+    /// - Returns: A ``Bytes`` sequence.
     @inlinable
     public func bytes<EncodedElement>(for target: EncodedElement.Type, mapping transform: (Self.Element) -> Bytes) -> Bytes {
         var bytes = Bytes()
@@ -106,9 +112,17 @@ extension RangeReplaceableCollection {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
+    ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
+    public init<
+        Bytes: BytesCollection,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
         try self.init(bytes: bytes, element: Element.self, mapping: transform)
     }
     
@@ -117,17 +131,38 @@ extension RangeReplaceableCollection {
     ///   - bytes: The bytes to transform.
     ///   - element: The element that was used to encode the byte sequence.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
+    ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
     @inlinable
-    public init<Bytes: BytesCollection, EncodedElement>(bytes: Bytes, element: EncodedElement.Type, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
-        let (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+    public init<
+        Bytes: BytesCollection,
+        EncodedElement,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        element: EncodedElement.Type,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
+        let elementSize: Int
+        let numberOfBytes: Int
+        let elementCount: Int
+        do {
+            (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+        } catch {
+            throw .castingFailure(error)
+        }
         
         var result = Self()
         result.reserveCapacity(elementCount)
         
         for sliceStart in stride(from: 0, to: numberOfBytes, by: elementSize) {
             let slice = bytes[sliceStart..<(sliceStart+elementSize)]
-            result.append(try transform(slice))
+            do {
+                result.append(try transform(slice))
+            } catch {
+                throw .transformationFailure(error)
+            }
         }
         
         self = result
@@ -139,9 +174,17 @@ extension Set {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
+    ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
+    public init<
+        Bytes: BytesCollection,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
         try self.init(bytes: bytes, element: Element.self, mapping: transform)
     }
     
@@ -150,17 +193,38 @@ extension Set {
     ///   - bytes: The bytes to transform.
     ///   - element: The element that was used to encode the byte sequence.
     ///   - transform: The transformation to perform on each element.
-    /// - Throws: `BytesError.invalidMemorySize` if the total size of the bytes sequence is not a multiple of the element's size.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
+    ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
     @inlinable
-    public init<Bytes: BytesCollection, EncodedElement>(bytes: Bytes, element: EncodedElement.Type, mapping transform: (Bytes.SubSequence) throws -> Self.Element) throws {
-        let (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+    public init<
+        Bytes: BytesCollection,
+        EncodedElement,
+        TransformationFailure: Error
+    >(
+        bytes: Bytes,
+        element: EncodedElement.Type,
+        mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
+    ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
+        let elementSize: Int
+        let numberOfBytes: Int
+        let elementCount: Int
+        do {
+            (elementSize, numberOfBytes, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+        } catch {
+            throw .castingFailure(error)
+        }
         
         var result = Self()
         result.reserveCapacity(elementCount)
         
         for sliceStart in stride(from: 0, to: numberOfBytes, by: elementSize) {
             let slice = bytes[sliceStart..<(sliceStart+elementSize)]
-            result.insert(try transform(slice))
+            do {
+                result.insert(try transform(slice))
+            } catch {
+                throw .transformationFailure(error)
+            }
         }
         
         self = result

--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -14,13 +14,13 @@ extension FixedWidthInteger {
         Bytes(casting: self.bigEndian)
     }
     
-    /// Initialize a fixed width integer from a contiguous sequence of Bytes representing a big endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a big endian integer.
+    /// Initialize a fixed width integer from a contiguous sequence of ``Bytes`` representing a big endian type.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a big endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws(BytesError.Casting) {
         self.init(bigEndian: try bigEndianBytes.casting())
     }
     
@@ -30,13 +30,13 @@ extension FixedWidthInteger {
         Bytes(casting: self.littleEndian)
     }
     
-    /// Initialize a fixed width integer from a contiguous sequence of Bytes representing a little endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a little endian integer.
+    /// Initialize a fixed width integer from a contiguous sequence of ``Bytes`` representing a little endian type.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a little endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws(BytesError.Casting) {
         self.init(littleEndian: try littleEndianBytes.casting())
     }
 }
@@ -48,14 +48,18 @@ extension Collection where Element: FixedWidthInteger {
         self.bytes(mapping: \.bigEndianBytes)
     }
     
-    /// Initialize a collection of integers with a sequence of Bytes representing a sequence of big endian types.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integers.
+    /// Initialize a collection of integers with a sequence of ``Bytes`` representing a sequence of big endian types.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws(BytesError.Casting) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
     /// The little endian representations of a collection of integers.
@@ -64,36 +68,48 @@ extension Collection where Element: FixedWidthInteger {
         self.bytes(mapping: \.littleEndianBytes)
     }
     
-    /// Initialize a collection of integers with a sequence of Bytes representing a sequence of little endian types.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integers.
+    /// Initialize a collection of integers with a sequence of ``Bytes`` representing a sequence of little endian types.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws(BytesError.Casting) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
 extension Set where Element: FixedWidthInteger {
-    /// Initialize a Set of integers with a sequence of Bytes representing a sequence of big endian types.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integers.
+    /// Initialize a Set of integers with a sequence of ``Bytes`` representing a sequence of big endian types.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
-        try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws(BytesError.Casting) {
+        do {
+            try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
-    /// Initialize a Set of integers with a sequence of Bytes representing a sequence of little endian types.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integers.
+    /// Initialize a Set of integers with a sequence of ``Bytes`` representing a sequence of little endian types.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws {
-        try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws(BytesError.Casting) {
+        do {
+            try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
@@ -108,10 +124,11 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) throws -> T {
-        try T(littleEndianBytes: next(Bytes.self, count: MemoryLayout<T>.size))
+    public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) throws(BytesError.InvalidMemorySize) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(littleEndianBytes: try next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -121,10 +138,11 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T {
-        try T(bigEndianBytes: next(Bytes.self, count: MemoryLayout<T>.size))
+    public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) throws(BytesError.InvalidMemorySize) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(bigEndianBytes: try next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -134,10 +152,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) throws -> T? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
+    public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) throws(BytesError.InvalidMemorySize) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(littleEndianBytes: $0) }
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -147,10 +167,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
+    public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) throws(BytesError.InvalidMemorySize) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(bigEndianBytes: $0) }
     }
     
     /// Advances by the next little endien integer if found, or throws if the next bytes in the iterator do not match.
@@ -159,11 +181,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<Int: FixedWidthInteger>(
         littleEndian integer: Int
-    ) throws {
+    ) throws(BytesError.CheckedSequenceNotFound) {
         try check(integer.littleEndianBytes)
     }
     
@@ -173,11 +195,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<Int: FixedWidthInteger>(
         bigEndian integer: Int
-    ) throws {
+    ) throws(BytesError.CheckedSequenceNotFound) {
         try check(integer.bigEndianBytes)
     }
     
@@ -188,12 +210,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         littleEndian integer: Int
-    ) throws -> Bool {
+    ) throws(BytesError.CheckedSequenceNotFound) -> Bool {
         try checkIfPresent(integer.littleEndianBytes)
     }
     
@@ -204,12 +226,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         bigEndian integer: Int
-    ) throws -> Bool {
+    ) throws(BytesError.CheckedSequenceNotFound) -> Bool {
         try checkIfPresent(integer.bigEndianBytes)
     }
 }
@@ -217,6 +239,7 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or throws if it could not.
@@ -226,11 +249,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T {
         try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
     }
@@ -242,11 +266,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T {
         try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
     }
@@ -258,11 +283,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
     }
@@ -274,11 +300,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize/invalidMemorySize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T? {
         try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
     }
@@ -289,11 +316,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Int: FixedWidthInteger>(
         littleEndian integer: Int
     ) async throws {
@@ -306,11 +334,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Int: FixedWidthInteger>(
         bigEndian integer: Int
     ) async throws {
@@ -324,11 +353,12 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         littleEndian integer: Int
@@ -343,15 +373,162 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the integer could not be identified.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         bigEndian integer: Int
     ) async throws -> Bool {
+        try await checkIfPresent(integer.bigEndianBytes)
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the next little endian integer in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete integer could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func next<T: FixedWidthInteger>(
+        littleEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(littleEndianBytes: try await next(Bytes.self, count: MemoryLayout<T>.size))
+    }
+    
+    /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete integer could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func next<T: FixedWidthInteger>(
+        bigEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(bigEndianBytes: try await next(Bytes.self, count: MemoryLayout<T>.size))
+    }
+    
+    /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete integer could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        littleEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(littleEndianBytes: $0) }
+    }
+    
+    /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete integer could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        bigEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(bigEndianBytes: $0) }
+    }
+    
+    /// Asynchronously advances by the next little endien integer if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the integer could not be identified.
+    @inlinable
+    public mutating func check<Int: FixedWidthInteger>(
+        littleEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) {
+        try await check(integer.littleEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next big endien integer if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the integer could not be identified.
+    @inlinable
+    public mutating func check<Int: FixedWidthInteger>(
+        bigEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) {
+        try await check(integer.bigEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next little endien integer if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the integer could not be identified.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Int: FixedWidthInteger>(
+        littleEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) -> Bool {
+        try await checkIfPresent(integer.littleEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next big endien integer if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the integer could not be identified.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Int: FixedWidthInteger>(
+        bigEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) -> Bool {
         try await checkIfPresent(integer.bigEndianBytes)
     }
 }

--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -14,13 +14,15 @@ extension FixedWidthInteger {
         Bytes(casting: self.bigEndian)
     }
     
-    /// Initialize a fixed width integer from a contiguous sequence of Bytes representing a big endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a big endian integer.
+    /// Initialize a fixed width integer from a contiguous sequence of ``Bytes`` representing a big endian type.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a big endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) {
         self.init(bigEndian: try bigEndianBytes.casting())
     }
     
@@ -30,13 +32,15 @@ extension FixedWidthInteger {
         Bytes(casting: self.littleEndian)
     }
     
-    /// Initialize a fixed width integer from a contiguous sequence of Bytes representing a little endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a little endian integer.
+    /// Initialize a fixed width integer from a contiguous sequence of ``Bytes`` representing a little endian type.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a little endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) {
         self.init(littleEndian: try littleEndianBytes.casting())
     }
 }
@@ -48,14 +52,20 @@ extension Collection where Element: FixedWidthInteger {
         self.bytes(mapping: \.bigEndianBytes)
     }
     
-    /// Initialize a collection of integers with a sequence of Bytes representing a sequence of big endian types.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integers.
+    /// Initialize a collection of integers with a sequence of ``Bytes`` representing a sequence of big endian types.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
     /// The little endian representations of a collection of integers.
@@ -64,36 +74,54 @@ extension Collection where Element: FixedWidthInteger {
         self.bytes(mapping: \.littleEndianBytes)
     }
     
-    /// Initialize a collection of integers with a sequence of Bytes representing a sequence of little endian types.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integers.
+    /// Initialize a collection of integers with a sequence of ``Bytes`` representing a sequence of little endian types.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
 extension Set where Element: FixedWidthInteger {
-    /// Initialize a Set of integers with a sequence of Bytes representing a sequence of big endian types.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integers.
+    /// Initialize a Set of integers with a sequence of ``Bytes`` representing a sequence of big endian types.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
-        try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) {
+        do {
+            try self.init(bytes: bigEndianBytes, mapping: Element.init(bigEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
-    /// Initialize a Set of integers with a sequence of Bytes representing a sequence of little endian types.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integers.
+    /// Initialize a Set of integers with a sequence of ``Bytes`` representing a sequence of little endian types.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integers.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws {
-        try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) {
+        do {
+            try self.init(bytes: littleEndianBytes, mapping: Element.init(littleEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
@@ -108,10 +136,13 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) throws -> T {
-        try T(littleEndianBytes: next(Bytes.self, count: MemoryLayout<T>.size))
+    public mutating func next<T: FixedWidthInteger>(
+        littleEndian type: T.Type
+    ) throws(BytesError.BufferSizeError) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(littleEndianBytes: try next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -121,10 +152,13 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T {
-        try T(bigEndianBytes: next(Bytes.self, count: MemoryLayout<T>.size))
+    public mutating func next<T: FixedWidthInteger>(
+        bigEndian type: T.Type
+    ) throws(BytesError.BufferSizeError) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(bigEndianBytes: try next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -134,10 +168,14 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) throws -> T? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        littleEndian type: T.Type
+    ) throws(BytesError.BufferSizeError) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(littleEndianBytes: $0) }
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -147,10 +185,14 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) throws -> T? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        bigEndian type: T.Type
+    ) throws(BytesError.BufferSizeError) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(bigEndianBytes: $0) }
     }
     
     /// Advances by the next little endien integer if found, or throws if the next bytes in the iterator do not match.
@@ -159,11 +201,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<Int: FixedWidthInteger>(
         littleEndian integer: Int
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         try check(integer.littleEndianBytes)
     }
     
@@ -173,11 +215,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<Int: FixedWidthInteger>(
         bigEndian integer: Int
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         try check(integer.bigEndianBytes)
     }
     
@@ -188,12 +230,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         littleEndian integer: Int
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         try checkIfPresent(integer.littleEndianBytes)
     }
     
@@ -204,12 +246,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         bigEndian integer: Int
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         try checkIfPresent(integer.bigEndianBytes)
     }
 }
@@ -217,6 +259,7 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or throws if it could not.
@@ -226,13 +269,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T {
-        try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
+    @_disfavoredOverload
+    public mutating func next<T: FixedWidthInteger>(
+        littleEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(littleEndianBytes: try await next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -242,13 +291,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T {
-        try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T>.size))
+    @_disfavoredOverload
+    public mutating func next<T: FixedWidthInteger>(
+        bigEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(bigEndianBytes: try await next(Bytes.self, count: MemoryLayout<T>.size))
     }
     
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -258,13 +313,20 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(littleEndian type: T.Type) async throws -> T? {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(littleEndianBytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        littleEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(littleEndianBytes: $0) }
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -274,13 +336,20 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of integer to decode.
     /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent<T: FixedWidthInteger>(bigEndian type: T.Type) async throws -> T? {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size).map { try T(bigEndianBytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        bigEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(bigEndianBytes: $0) }
     }
     
     /// Asynchronously advances by the next little endien integer if found, or throws if the next bytes in the iterator do not match.
@@ -289,14 +358,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Int: FixedWidthInteger>(
         littleEndian integer: Int
-    ) async throws {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
         try await check(integer.littleEndianBytes)
     }
     
@@ -306,14 +378,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Int: FixedWidthInteger>(
         bigEndian integer: Int
-    ) async throws {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
         try await check(integer.bigEndianBytes)
     }
     
@@ -324,15 +399,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         littleEndian integer: Int
-    ) async throws -> Bool {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
         try await checkIfPresent(integer.littleEndianBytes)
     }
     
@@ -343,15 +421,180 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<Int: FixedWidthInteger>(
         bigEndian integer: Int
-    ) async throws -> Bool {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
+        try await checkIfPresent(integer.bigEndianBytes)
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the next little endian integer in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next<T: FixedWidthInteger>(
+        littleEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(littleEndianBytes: try await next(Bytes.self, count: MemoryLayout<T>.size))
+    }
+    
+    /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next<T: FixedWidthInteger>(
+        bigEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> T {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! T(bigEndianBytes: try await next(Bytes.self, count: MemoryLayout<T>.size))
+    }
+    
+    /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        littleEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(littleEndianBytes: $0) }
+    }
+    
+    /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of integer to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: An integer of type `type`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent<T: FixedWidthInteger>(
+        bigEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> T? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+            .map { try! T(bigEndianBytes: $0) }
+    }
+    
+    /// Asynchronously advances by the next little endien integer if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<Int: FixedWidthInteger>(
+        littleEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        try await check(integer.littleEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next big endien integer if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<Int: FixedWidthInteger>(
+        bigEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        try await check(integer.bigEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next little endien integer if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Int: FixedWidthInteger>(
+        littleEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
+        try await checkIfPresent(integer.littleEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next big endien integer if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Int: FixedWidthInteger>(
+        bigEndian integer: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
         try await checkIfPresent(integer.bigEndianBytes)
     }
 }

--- a/Sources/Bytes/RawRepresentable.swift
+++ b/Sources/Bytes/RawRepresentable.swift
@@ -8,23 +8,30 @@
 //
 
 extension RawRepresentable {
-    /// The Bytes representation of the `rawValue`.
+    /// The ``Bytes`` representation of the `rawValue`.
     @inlinable
     public var rawBytes: Bytes {
         Bytes(casting: self.rawValue)
     }
     
-    /// Initialize a raw representable type from a contiguous sequence of Bytes representing the `rawValue`.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a big endian integer.
+    /// Initialize a raw representable type from a contiguous sequence of ``Bytes`` representing the `rawValue`.
+    /// - Parameter rawBytes: The ``Bytes`` to interpret as the raw value for the type.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the `rawValue`'s type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence does not match the size of the `rawValue`'s type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(rawBytes: Bytes) throws {
-        guard let value = Self(rawValue: try rawBytes.casting()) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        rawBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) {
+        let rawValue: RawValue
+        do {
+            rawValue = try rawBytes.casting()
+        } catch {
+            throw .castingFailure(error)
         }
+        guard let value = Self(rawValue: rawValue)
+        else { throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)") }
         self = value
     }
 }
@@ -36,17 +43,24 @@ extension RawRepresentable where RawValue: FixedWidthInteger {
         self.rawValue.bigEndianBytes
     }
     
-    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of Bytes representing a big endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a big endian integer.
+    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of ``Bytes`` representing a big endian type.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a big endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
-        guard let value = Self(rawValue: try RawValue(bigEndianBytes: bigEndianBytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) {
+        let rawValue: RawValue
+        do {
+            rawValue = try RawValue(bigEndianBytes: bigEndianBytes)
+        } catch {
+            throw .castingFailure(error)
         }
+        guard let value = Self(rawValue: rawValue)
+        else { throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)") }
         self = value
     }
     
@@ -56,58 +70,73 @@ extension RawRepresentable where RawValue: FixedWidthInteger {
         self.rawValue.littleEndianBytes
     }
     
-    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of Bytes representing a little endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a little endian integer.
+    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of ``Bytes`` representing a little endian type.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a little endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws  {
-        guard let value = Self(rawValue: try RawValue(littleEndianBytes: littleEndianBytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) {
+        let rawValue: RawValue
+        do {
+            rawValue = try RawValue(littleEndianBytes: littleEndianBytes)
+        } catch {
+            throw .castingFailure(error)
         }
+        guard let value = Self(rawValue: rawValue)
+        else { throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)") }
         self = value
     }
 }
 
 extension RawRepresentable where RawValue: StringProtocol {
-    /// Get the UTF-8 representation of the `rawValue`'s string as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of the `rawValue`'s string as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         self.rawValue.utf8Bytes
     }
     
-    /// Initialize a raw representable type as a String from a contiguous sequence of Bytes representing the `rawValue`.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
+    /// Initialize a raw representable type as a String from a contiguous sequence of ``Bytes`` representing the `rawValue`.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
     /// - Throws:
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws {
-        guard let value = Self(rawValue: RawValue(utf8Bytes: utf8Bytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
-        }
+    public init<Bytes: BytesCollection>(
+        utf8Bytes: Bytes
+    ) throws(BytesError.RawRepresentableError<Never>) {
+        guard let value = Self(rawValue: RawValue(utf8Bytes: utf8Bytes))
+        else { throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)") }
         self = value
     }
 }
 
 extension RawRepresentable where RawValue == Character {
-    /// Get the UTF-8 representation of the `rawValue`'s character as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of the `rawValue`'s character as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         self.rawValue.utf8Bytes
     }
     
-    /// Initialize a raw representable type as a Character from a contiguous sequence of Bytes representing the `rawValue`.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
+    /// Initialize a raw representable type as a Character from a contiguous sequence of ``Bytes`` representing the `rawValue`.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
     /// - Throws:
-    ///     - `BytesError.invalidCharacterByteSequence` if the byte sequence does not represent a single character.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/CharacterDecodingError/invalidCharacterByteSequence`` if the byte sequence does not represent a single character.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws {
-        guard let value = try Self(rawValue: RawValue(utf8Bytes: utf8Bytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        utf8Bytes: Bytes
+    ) throws(BytesError.RawRepresentable.CharacterDecodingError) {
+        let rawValue: RawValue
+        do {
+            rawValue = try RawValue(utf8Bytes: utf8Bytes)
+        } catch {
+            throw .castingFailure(error)
         }
+        guard let value = Self(rawValue: rawValue)
+        else { throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)") }
         self = value
     }
 }
@@ -115,21 +144,27 @@ extension RawRepresentable where RawValue == Character {
 // MARK: - Collection Extensions
 
 extension Collection where Element: RawRepresentable {
-    /// The Bytes representations of a collection of `rawValue`s.
+    /// The ``Bytes`` representations of a collection of `rawValue`s.
     @inlinable
     public var rawBytes: Bytes {
         self.bytes(for: Element.RawValue.self, mapping: \.rawBytes)
     }
     
-    /// Initialize a collection of raw representable types with a sequence of Bytes representing the `rawValue`s.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of `rawValue`s.
+    /// Initialize a collection of raw representable types with a sequence of ``Bytes`` representing the `rawValue`s.
+    /// - Parameter rawBytes: The ``Bytes`` to interpret as a sequence of `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(rawBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: rawBytes, element: Element.RawValue.self, mapping: Element.init(rawBytes:))
+    public init<Bytes: BytesCollection>(
+        rawBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: rawBytes, element: Element.RawValue.self, mapping: Element.init(rawBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
@@ -140,15 +175,21 @@ extension Collection where Element: RawRepresentable, Element.RawValue: FixedWid
         self.bytes(for: Element.RawValue.self, mapping: \.bigEndianBytes)
     }
     
-    /// Initialize a collection of raw representable types with a sequence of Bytes representing a sequence of big endian `rawValue`s.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integer `rawValue`s.
+    /// Initialize a collection of raw representable types with a sequence of ``Bytes`` representing a sequence of big endian `rawValue`s.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: bigEndianBytes, element: Element.RawValue.self, mapping: Element.init(bigEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: bigEndianBytes, element: Element.RawValue.self, mapping: Element.init(bigEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
     /// The little endian representations of a collection of `rawValue` integers.
@@ -157,54 +198,78 @@ extension Collection where Element: RawRepresentable, Element.RawValue: FixedWid
         self.bytes(for: Element.RawValue.self, mapping: \.littleEndianBytes)
     }
     
-    /// Initialize a collection of raw representable types with a sequence of Bytes representing a sequence of little endian `rawValue`s.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integer `rawValue`s.
+    /// Initialize a collection of raw representable types with a sequence of ``Bytes`` representing a sequence of little endian `rawValue`s.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: littleEndianBytes, element: Element.RawValue.self, mapping: Element.init(littleEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: littleEndianBytes, element: Element.RawValue.self, mapping: Element.init(littleEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
 // MARK: - Set Extensions
 
 extension Set where Element: RawRepresentable {
-    /// Initialize a Set of raw representable types with a sequence of Bytes representing the `rawValue`s.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of big endian integer.
+    /// Initialize a Set of raw representable types with a sequence of ``Bytes`` representing the `rawValue`s.
+    /// - Parameter rawBytes: The ``Bytes`` to interpret as a sequence of big endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(rawBytes: Bytes) throws {
-        try self.init(bytes: rawBytes, element: Element.RawValue.self, mapping: Element.init(rawBytes:))
+    public init<Bytes: BytesCollection>(
+        rawBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) {
+        do {
+            try self.init(bytes: rawBytes, element: Element.RawValue.self, mapping: Element.init(rawBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
 extension Set where Element: RawRepresentable, Element.RawValue: FixedWidthInteger {
-    /// Initialize a Set of raw representable types with a sequence of Bytes representing a sequence of big endian `rawValue`s.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integer `rawValue`s.
+    /// Initialize a Set of raw representable types with a sequence of ``Bytes`` representing a sequence of big endian `rawValue`s.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
-        try self.init(bytes: bigEndianBytes, element: Element.RawValue.self, mapping: Element.init(bigEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) {
+        do {
+            try self.init(bytes: bigEndianBytes, element: Element.RawValue.self, mapping: Element.init(bigEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
-    /// Initialize a Set of raw representable types with a sequence of Bytes representing a sequence of little endian `rawValue`s.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integer `rawValue`s.
+    /// Initialize a Set of raw representable types with a sequence of ``Bytes`` representing a sequence of little endian `rawValue`s.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws {
-        try self.init(bytes: littleEndianBytes, element: Element.RawValue.self, mapping: Element.init(littleEndianBytes:))
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentable.ContiguousBytes.BufferSizeError) {
+        do {
+            try self.init(bytes: littleEndianBytes, element: Element.RawValue.self, mapping: Element.init(littleEndianBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
@@ -219,10 +284,29 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete raw representable could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public mutating func next<T: RawRepresentable>(raw type: T.Type) throws -> T {
-        try T(rawBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
+    public mutating func next<T: RawRepresentable>(
+        raw type: T.Type
+    ) throws(BytesError.RawRepresentable.BufferSizeError) -> T {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        do {
+            return try T(rawBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Advances to the next raw representable in the squence and returns it, or ends the sequence if there is no next element.
@@ -232,10 +316,30 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete raw representable could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(raw type: T.Type) throws -> T? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        raw type: T.Type
+    ) throws(BytesError.RawRepresentable.BufferSizeError) -> T? {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(rawBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Advances by the specified raw representable value if found, or throws if the next bytes in the iterator do not match.
@@ -244,11 +348,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter value: The raw value to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
     @inlinable
     public mutating func check<Raw: RawRepresentable>(
         raw value: Raw
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         try check(value.rawBytes)
     }
     
@@ -259,12 +363,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter value: The raw value to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<Raw: RawRepresentable>(
         raw value: Raw
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         try checkIfPresent(value.rawBytes)
     }
 }
@@ -277,10 +381,28 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next<T: RawRepresentable>(littleEndian type: T.Type) throws -> T where T.RawValue: FixedWidthInteger {
-        try T(littleEndianBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
+    public mutating func next<T: RawRepresentable>(
+        littleEndian type: T.Type
+    ) throws(BytesError.RawRepresentable.BufferSizeError) -> T where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        do {
+            return try T(littleEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -290,10 +412,28 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next<T: RawRepresentable>(bigEndian type: T.Type) throws -> T where T.RawValue: FixedWidthInteger {
-        try T(bigEndianBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
+    public mutating func next<T: RawRepresentable>(
+        bigEndian type: T.Type
+    ) throws(BytesError.RawRepresentable.BufferSizeError) -> T where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        do {
+            return try T(bigEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -303,10 +443,29 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(littleEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        littleEndian type: T.Type
+    ) throws(BytesError.RawRepresentable.BufferSizeError) -> T? where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(littleEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -316,10 +475,29 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        bigEndian type: T.Type
+    ) throws(BytesError.RawRepresentable.BufferSizeError) -> T? where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(bigEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Advances by the next byte if found, or throws if the next bytes in the iterator do not match.
@@ -328,11 +506,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<RawInt: RawRepresentable>(
         _ integer: RawInt
-    ) throws where RawInt.RawValue == UInt8 {
+    ) throws(BytesError.SequenceCheckError) where RawInt.RawValue == UInt8 {
         try check(integer.rawValue)
     }
     
@@ -342,11 +520,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<RawInt: RawRepresentable>(
         littleEndian integer: RawInt
-    ) throws where RawInt.RawValue: FixedWidthInteger {
+    ) throws(BytesError.SequenceCheckError) where RawInt.RawValue: FixedWidthInteger {
         try check(integer.littleEndianBytes)
     }
     
@@ -356,11 +534,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     public mutating func check<RawInt: RawRepresentable>(
         bigEndian integer: RawInt
-    ) throws where RawInt.RawValue: FixedWidthInteger {
+    ) throws(BytesError.SequenceCheckError) where RawInt.RawValue: FixedWidthInteger {
         try check(integer.bigEndianBytes)
     }
     
@@ -371,12 +549,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
         _ integer: RawInt
-    ) throws -> Bool where RawInt.RawValue == UInt8 {
+    ) throws(BytesError.SequenceCheckError) -> Bool where RawInt.RawValue == UInt8 {
         try checkIfPresent(integer.rawValue)
     }
     
@@ -387,12 +565,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
         littleEndian integer: RawInt
-    ) throws -> Bool where RawInt.RawValue: FixedWidthInteger {
+    ) throws(BytesError.SequenceCheckError) -> Bool where RawInt.RawValue: FixedWidthInteger {
         try checkIfPresent(integer.littleEndianBytes)
     }
     
@@ -403,12 +581,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
         bigEndian integer: RawInt
-    ) throws -> Bool where RawInt.RawValue: FixedWidthInteger {
+    ) throws(BytesError.SequenceCheckError) -> Bool where RawInt.RawValue: FixedWidthInteger {
         try checkIfPresent(integer.bigEndianBytes)
     }
 }
@@ -420,11 +598,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
     @inlinable
     public mutating func check<RawCharacter: RawRepresentable>(
         utf8 character: RawCharacter
-    ) throws where RawCharacter.RawValue == Character {
+    ) throws(BytesError.SequenceCheckError) where RawCharacter.RawValue == Character {
         try check(character.utf8Bytes)
     }
     
@@ -438,11 +616,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
     @inlinable
     public mutating func check<RawString: RawRepresentable>(
         utf8 string: RawString
-    ) throws where RawString.RawValue: StringProtocol {
+    ) throws(BytesError.SequenceCheckError) where RawString.RawValue: StringProtocol {
         try check(string.utf8Bytes)
     }
     
@@ -453,12 +631,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawCharacter: RawRepresentable>(
         utf8 character: RawCharacter
-    ) throws -> Bool where RawCharacter.RawValue == Character {
+    ) throws(BytesError.SequenceCheckError) -> Bool where RawCharacter.RawValue == Character {
         try checkIfPresent(character.utf8Bytes)
     }
     
@@ -473,12 +651,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<RawString: RawRepresentable>(
         utf8 string: RawString
-    ) throws -> Bool where RawString.RawValue: StringProtocol {
+    ) throws(BytesError.SequenceCheckError) -> Bool where RawString.RawValue: StringProtocol {
         try checkIfPresent(string.utf8Bytes)
     }
 }
@@ -486,6 +664,7 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next raw representable in the squence and returns it, or throws if it could not.
@@ -495,13 +674,34 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete raw representable could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next<T: RawRepresentable>(raw type: T.Type) async throws -> T {
-        try T(rawBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
+    @_disfavoredOverload
+    public mutating func next<T: RawRepresentable>(
+        raw type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.RawRepresentable.BufferSizeError) -> T {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try await next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try T(rawBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Asynchronously advances to the next raw representable in the squence and returns it, or ends the sequence if there is no next element.
@@ -511,13 +711,35 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete raw representable could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(raw type: T.Type) async throws -> T? {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        raw type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.RawRepresentable.BufferSizeError) -> T? {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(rawBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Asynchronously advances by the specified raw representable value if found, or throws if the next bytes in the iterator do not match.
@@ -526,14 +748,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter value: The raw value to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<Raw: RawRepresentable>(
         raw value: Raw
-    ) async throws {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
         try await check(value.rawBytes)
     }
     
@@ -544,15 +769,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter value: The raw value to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<Raw: RawRepresentable>(
         raw value: Raw
-    ) async throws -> Bool {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
         try await checkIfPresent(value.rawBytes)
     }
 }
@@ -566,13 +794,34 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next<T: RawRepresentable>(littleEndian type: T.Type) async throws -> T where T.RawValue: FixedWidthInteger {
-        try T(littleEndianBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
+    @_disfavoredOverload
+    public mutating func next<T: RawRepresentable>(
+        littleEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.RawRepresentable.BufferSizeError) -> T where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try await next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try T(littleEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
@@ -582,13 +831,34 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T where T.RawValue: FixedWidthInteger {
-        try T(bigEndianBytes: await next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
+    @_disfavoredOverload
+    public mutating func next<T: RawRepresentable>(
+        bigEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.RawRepresentable.BufferSizeError) -> T where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try await next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try T(bigEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -598,13 +868,35 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(littleEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        littleEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.RawRepresentable.BufferSizeError) -> T? where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(littleEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
@@ -614,13 +906,35 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) async throws -> T? where T.RawValue: FixedWidthInteger {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        bigEndian type: T.Type
+    ) async throws(BytesError.Iteration<any Error>.RawRepresentable.BufferSizeError) -> T? where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(bigEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
     }
     
     /// Asynchronously advances by the next byte if found, or throws if the next bytes in the iterator do not match.
@@ -629,14 +943,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<RawInt: RawRepresentable>(
         _ integer: RawInt
-    ) async throws where RawInt.RawValue == UInt8 {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) where RawInt.RawValue == UInt8 {
         try await check(integer.rawValue)
     }
     
@@ -646,14 +963,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<RawInt: RawRepresentable>(
         littleEndian integer: RawInt
-    ) async throws where RawInt.RawValue: FixedWidthInteger {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) where RawInt.RawValue: FixedWidthInteger {
         try await check(integer.littleEndianBytes)
     }
     
@@ -663,14 +983,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<RawInt: RawRepresentable>(
         bigEndian integer: RawInt
-    ) async throws where RawInt.RawValue: FixedWidthInteger {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) where RawInt.RawValue: FixedWidthInteger {
         try await check(integer.bigEndianBytes)
     }
     
@@ -681,15 +1004,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
         _ integer: RawInt
-    ) async throws -> Bool where RawInt.RawValue == UInt8 {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool where RawInt.RawValue == UInt8 {
         try await checkIfPresent(integer.rawValue)
     }
     
@@ -700,15 +1026,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
         littleEndian integer: RawInt
-    ) async throws -> Bool where RawInt.RawValue: FixedWidthInteger {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool where RawInt.RawValue: FixedWidthInteger {
         try await checkIfPresent(integer.littleEndianBytes)
     }
     
@@ -719,15 +1048,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter integer: The raw integer to check for.
     /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the integer could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<RawInt: RawRepresentable>(
         bigEndian integer: RawInt
-    ) async throws -> Bool where RawInt.RawValue: FixedWidthInteger {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool where RawInt.RawValue: FixedWidthInteger {
         try await checkIfPresent(integer.bigEndianBytes)
     }
 }
@@ -740,14 +1072,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<RawCharacter: RawRepresentable>(
         utf8 character: RawCharacter
-    ) async throws where RawCharacter.RawValue == Character {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) where RawCharacter.RawValue == Character {
         try await check(character.utf8Bytes)
     }
     
@@ -761,14 +1096,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<RawString: RawRepresentable>(
         utf8 string: RawString
-    ) async throws where RawString.RawValue: StringProtocol {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) where RawString.RawValue: StringProtocol {
         try await check(string.utf8Bytes)
     }
     
@@ -779,15 +1117,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<RawCharacter: RawRepresentable>(
         utf8 character: RawCharacter
-    ) async throws -> Bool where RawCharacter.RawValue == Character {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool where RawCharacter.RawValue == Character {
         try await checkIfPresent(character.utf8Bytes)
     }
     
@@ -802,15 +1143,477 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent<RawString: RawRepresentable>(
         utf8 string: RawString
-    ) async throws -> Bool where RawString.RawValue: StringProtocol {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool where RawString.RawValue: StringProtocol {
+        try await checkIfPresent(string.utf8Bytes)
+    }
+}
+#endif
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the next raw representable in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete raw representable could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of raw representable to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A raw representable type as a fixed width integer of type `type`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete raw representable could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next<T: RawRepresentable>(
+        raw type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.RawRepresentable.BufferSizeError) -> T {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try await next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try T(rawBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
+    }
+    
+    /// Asynchronously advances to the next raw representable in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete raw representable could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of raw representable to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A raw representable of type `type`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete raw representable could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        raw type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.RawRepresentable.BufferSizeError) -> T? {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(rawBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
+    }
+    
+    /// Asynchronously advances by the specified raw representable value if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a raw value to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter value: The raw value to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<Raw: RawRepresentable>(
+        raw value: Raw,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        try await check(value.rawBytes)
+    }
+    
+    /// Asynchronously advances by the specified raw representable value if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a raw value to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter value: The raw value to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the string was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<Raw: RawRepresentable>(
+        raw value: Raw,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
+        try await checkIfPresent(value.rawBytes)
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the next little endian integer in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of raw representable to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A raw representable type as a fixed width integer of type `type`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next<T: RawRepresentable>(
+        littleEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.RawRepresentable.BufferSizeError) -> T where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try await next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try T(littleEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
+    }
+    
+    /// Asynchronously advances to the next big endian integer in the squence and returns it, or throws if it could not.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of raw representable to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A raw representable type as a fixed width integer of type `type`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next<T: RawRepresentable>(
+        bigEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.RawRepresentable.BufferSizeError) -> T where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes
+        do {
+            rawBytes = try await next(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try T(bigEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
+    }
+    
+    /// Asynchronously advances to the next little endian integer in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of raw representable to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        littleEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.RawRepresentable.BufferSizeError) -> T? where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(littleEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
+    }
+    
+    /// Asynchronously advances to the next big endian integer in the squence and returns it, or ends the sequence if there is no next element.
+    ///
+    /// If a complete integer could not be constructed, an error is thrown and the sequence should be considered finished.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: The type of raw representable to decode.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete integer could not be returned by the time the sequence ended.
+    ///     - ``BytesError/RawRepresentableError/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent<T: RawRepresentable>(
+        bigEndian type: T.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.RawRepresentable.BufferSizeError) -> T? where T.RawValue: FixedWidthInteger {
+        let rawBytes: Bytes?
+        do {
+            rawBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let rawBytes else { return nil }
+        do {
+            return try T(bigEndianBytes: rawBytes)
+        } catch {
+            switch error {
+            case .castingFailure:
+                fatalError("Transforming the raw value should always succeed.")
+            case .invalidRawRepresentableByteSequence(let rawType):
+                throw .invalidRawRepresentableByteSequence(rawType: rawType)
+            }
+        }
+    }
+    
+    /// Asynchronously advances by the next byte if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The raw integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<RawInt: RawRepresentable>(
+        _ integer: RawInt,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) where RawInt.RawValue == UInt8 {
+        try await check(integer.rawValue)
+    }
+    
+    /// Asynchronously advances by the next little endien integer if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The raw integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<RawInt: RawRepresentable>(
+        littleEndian integer: RawInt,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) where RawInt.RawValue: FixedWidthInteger {
+        try await check(integer.littleEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next big endien integer if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The raw integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<RawInt: RawRepresentable>(
+        bigEndian integer: RawInt,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) where RawInt.RawValue: FixedWidthInteger {
+        try await check(integer.bigEndianBytes)
+    }
+    
+    /// Asynchronously advances by the byte if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The raw integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<RawInt: RawRepresentable>(
+        _ integer: RawInt,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool where RawInt.RawValue == UInt8 {
+        try await checkIfPresent(integer.rawValue)
+    }
+    
+    /// Asynchronously advances by the next little endien integer if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The raw integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<RawInt: RawRepresentable>(
+        littleEndian integer: RawInt,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool where RawInt.RawValue: FixedWidthInteger {
+        try await checkIfPresent(integer.littleEndianBytes)
+    }
+    
+    /// Asynchronously advances by the next big endien integer if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect an integer to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter integer: The raw integer to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the integer was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the integer could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<RawInt: RawRepresentable>(
+        bigEndian integer: RawInt,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool where RawInt.RawValue: FixedWidthInteger {
+        try await checkIfPresent(integer.bigEndianBytes)
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances by the specified UTF-8 encoded raw value Character if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a raw value Character to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter character: The character to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<RawCharacter: RawRepresentable>(
+        utf8 character: RawCharacter,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) where RawCharacter.RawValue == Character {
+        try await check(character.utf8Bytes)
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded raw value String if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a raw value String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the String is empty, this method won't do anything.
+    ///
+    /// - Note: The string will not check for null termination unless a null character is specified.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter string: The string to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<RawString: RawRepresentable>(
+        utf8 string: RawString,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) where RawString.RawValue: StringProtocol {
+        try await check(string.utf8Bytes)
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded raw value Character if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a raw value Character to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter character: The character to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the character was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<RawCharacter: RawRepresentable>(
+        utf8 character: RawCharacter,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool where RawCharacter.RawValue == Character {
+        try await checkIfPresent(character.utf8Bytes)
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded raw value String if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a raw value String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the String is empty, this method won't do anything.
+    ///
+    /// - Note: The string will not check for null termination unless a null character is specified.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter string: The string to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the character was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<RawString: RawRepresentable>(
+        utf8 string: RawString,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool where RawString.RawValue: StringProtocol {
         try await checkIfPresent(string.utf8Bytes)
     }
 }

--- a/Sources/Bytes/RawRepresentable.swift
+++ b/Sources/Bytes/RawRepresentable.swift
@@ -8,22 +8,30 @@
 //
 
 extension RawRepresentable {
-    /// The Bytes representation of the `rawValue`.
+    /// The ``Bytes`` representation of the `rawValue`.
     @inlinable
     public var rawBytes: Bytes {
         Bytes(casting: self.rawValue)
     }
     
-    /// Initialize a raw representable type from a contiguous sequence of Bytes representing the `rawValue`.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a big endian integer.
+    /// Initialize a raw representable type from a contiguous sequence of ``Bytes`` representing the `rawValue`.
+    /// - Parameter rawBytes: The ``Bytes`` to interpret as the raw value for the type.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the `rawValue`'s type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence does not match the size of the `rawValue`'s type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(rawBytes: Bytes) throws {
-        guard let value = Self(rawValue: try rawBytes.casting()) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        rawBytes: Bytes
+    ) throws(BytesError.RawRepresentableCasting) {
+        let rawValue: RawValue
+        do {
+            rawValue = try rawBytes.casting()
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let value = Self(rawValue: rawValue) else {
+            throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)")
         }
         self = value
     }
@@ -36,16 +44,24 @@ extension RawRepresentable where RawValue: FixedWidthInteger {
         self.rawValue.bigEndianBytes
     }
     
-    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of Bytes representing a big endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a big endian integer.
+    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of ``Bytes`` representing a big endian type.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a big endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
-        guard let value = Self(rawValue: try RawValue(bigEndianBytes: bigEndianBytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        bigEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentableCasting) {
+        let rawValue: RawValue
+        do {
+            rawValue = try RawValue(bigEndianBytes: bigEndianBytes)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let value = Self(rawValue: rawValue) else {
+            throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)")
         }
         self = value
     }
@@ -56,57 +72,75 @@ extension RawRepresentable where RawValue: FixedWidthInteger {
         self.rawValue.littleEndianBytes
     }
     
-    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of Bytes representing a little endian type.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a little endian integer.
+    /// Initialize a raw representable type as a fixed width integer from a contiguous sequence of ``Bytes`` representing a little endian type.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a little endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence does not match the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence does not match the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws  {
-        guard let value = Self(rawValue: try RawValue(littleEndianBytes: littleEndianBytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        littleEndianBytes: Bytes
+    ) throws(BytesError.RawRepresentableCasting) {
+        let rawValue: RawValue
+        do {
+            rawValue = try RawValue(littleEndianBytes: littleEndianBytes)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let value = Self(rawValue: rawValue) else {
+            throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)")
         }
         self = value
     }
 }
 
 extension RawRepresentable where RawValue: StringProtocol {
-    /// Get the UTF-8 representation of the `rawValue`'s string as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of the `rawValue`'s string as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         self.rawValue.utf8Bytes
     }
     
-    /// Initialize a raw representable type as a String from a contiguous sequence of Bytes representing the `rawValue`.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
+    /// Initialize a raw representable type as a String from a contiguous sequence of ``Bytes`` representing the `rawValue`.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
     /// - Throws:
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(
+        utf8Bytes: Bytes
+    ) throws(BytesError.RawRepresentable<Never>) {
         guard let value = Self(rawValue: RawValue(utf8Bytes: utf8Bytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+            throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)")
         }
         self = value
     }
 }
 
 extension RawRepresentable where RawValue == Character {
-    /// Get the UTF-8 representation of the `rawValue`'s character as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of the `rawValue`'s character as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         self.rawValue.utf8Bytes
     }
     
-    /// Initialize a raw representable type as a Character from a contiguous sequence of Bytes representing the `rawValue`.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
+    /// Initialize a raw representable type as a Character from a contiguous sequence of ``Bytes`` representing the `rawValue`.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
     /// - Throws:
-    ///     - `BytesError.invalidCharacterByteSequence` if the byte sequence does not represent a single character.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/Character`` if the byte sequence does not represent a single character.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
-    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws {
-        guard let value = try Self(rawValue: RawValue(utf8Bytes: utf8Bytes)) else {
-            throw BytesError.invalidRawRepresentableByteSequence
+    public init<Bytes: BytesCollection>(
+        utf8Bytes: Bytes
+    ) throws(BytesError.RawRepresentableCharacter) {
+        let rawValue: RawValue
+        do {
+            rawValue = try RawValue(utf8Bytes: utf8Bytes)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let value = Self(rawValue: rawValue) else {
+            throw .invalidRawRepresentableByteSequence(rawType: "\(RawValue.self)")
         }
         self = value
     }
@@ -115,18 +149,18 @@ extension RawRepresentable where RawValue == Character {
 // MARK: - Collection Extensions
 
 extension Collection where Element: RawRepresentable {
-    /// The Bytes representations of a collection of `rawValue`s.
+    /// The ``Bytes`` representations of a collection of `rawValue`s.
     @inlinable
     public var rawBytes: Bytes {
         self.bytes(for: Element.RawValue.self, mapping: \.rawBytes)
     }
     
-    /// Initialize a collection of raw representable types with a sequence of Bytes representing the `rawValue`s.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of `rawValue`s.
+    /// Initialize a collection of raw representable types with a sequence of ``Bytes`` representing the `rawValue`s.
+    /// - Parameter rawBytes: The ``Bytes`` to interpret as a sequence of `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
     public init<Bytes: BytesCollection>(rawBytes: Bytes) throws where Self: RangeReplaceableCollection {
         try self.init(bytes: rawBytes, element: Element.RawValue.self, mapping: Element.init(rawBytes:))
@@ -140,12 +174,12 @@ extension Collection where Element: RawRepresentable, Element.RawValue: FixedWid
         self.bytes(for: Element.RawValue.self, mapping: \.bigEndianBytes)
     }
     
-    /// Initialize a collection of raw representable types with a sequence of Bytes representing a sequence of big endian `rawValue`s.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integer `rawValue`s.
+    /// Initialize a collection of raw representable types with a sequence of ``Bytes`` representing a sequence of big endian `rawValue`s.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
     public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
         try self.init(bytes: bigEndianBytes, element: Element.RawValue.self, mapping: Element.init(bigEndianBytes:))
@@ -157,12 +191,12 @@ extension Collection where Element: RawRepresentable, Element.RawValue: FixedWid
         self.bytes(for: Element.RawValue.self, mapping: \.littleEndianBytes)
     }
     
-    /// Initialize a collection of raw representable types with a sequence of Bytes representing a sequence of little endian `rawValue`s.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integer `rawValue`s.
+    /// Initialize a collection of raw representable types with a sequence of ``Bytes`` representing a sequence of little endian `rawValue`s.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
     public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws where Self: RangeReplaceableCollection {
         try self.init(bytes: littleEndianBytes, element: Element.RawValue.self, mapping: Element.init(littleEndianBytes:))
@@ -172,12 +206,12 @@ extension Collection where Element: RawRepresentable, Element.RawValue: FixedWid
 // MARK: - Set Extensions
 
 extension Set where Element: RawRepresentable {
-    /// Initialize a Set of raw representable types with a sequence of Bytes representing the `rawValue`s.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of big endian integer.
+    /// Initialize a Set of raw representable types with a sequence of ``Bytes`` representing the `rawValue`s.
+    /// - Parameter rawBytes: The ``Bytes`` to interpret as a sequence of big endian integer.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if a byte sub-sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the byte sequence does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the `rawValue`'s type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if a byte sub-sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the byte sequence does not correspond with a valid raw value.
     @inlinable
     public init<Bytes: BytesCollection>(rawBytes: Bytes) throws {
         try self.init(bytes: rawBytes, element: Element.RawValue.self, mapping: Element.init(rawBytes:))
@@ -185,23 +219,23 @@ extension Set where Element: RawRepresentable {
 }
 
 extension Set where Element: RawRepresentable, Element.RawValue: FixedWidthInteger {
-    /// Initialize a Set of raw representable types with a sequence of Bytes representing a sequence of big endian `rawValue`s.
-    /// - Parameter bigEndianBytes: The Bytes to interpret as a sequence of big endian integer `rawValue`s.
+    /// Initialize a Set of raw representable types with a sequence of ``Bytes`` representing a sequence of big endian `rawValue`s.
+    /// - Parameter bigEndianBytes: The ``Bytes`` to interpret as a sequence of big endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
     public init<Bytes: BytesCollection>(bigEndianBytes: Bytes) throws {
         try self.init(bytes: bigEndianBytes, element: Element.RawValue.self, mapping: Element.init(bigEndianBytes:))
     }
     
-    /// Initialize a Set of raw representable types with a sequence of Bytes representing a sequence of little endian `rawValue`s.
-    /// - Parameter littleEndianBytes: The Bytes to interpret as a sequence of little endian integer `rawValue`s.
+    /// Initialize a Set of raw representable types with a sequence of ``Bytes`` representing a sequence of little endian `rawValue`s.
+    /// - Parameter littleEndianBytes: The ``Bytes`` to interpret as a sequence of little endian integer `rawValue`s.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of the size of the integer type.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidRawRepresentableByteSequence` if the integer does not correspond with a valid raw value.
+    ///     - ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if the byte sequence is not a multiple of the size of the integer type.
+    ///     - ``BytesError/Casting/contiguousMemoryUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/RawRepresentable/invalidRawRepresentableByteSequence(rawType:)-enum.case`` if the integer does not correspond with a valid raw value.
     @inlinable
     public init<Bytes: BytesCollection>(littleEndianBytes: Bytes) throws {
         try self.init(bytes: littleEndianBytes, element: Element.RawValue.self, mapping: Element.init(littleEndianBytes:))
@@ -219,7 +253,7 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete raw representable could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(raw type: T.Type) throws -> T {
         try T(rawBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
@@ -232,7 +266,7 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete raw representable could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(raw type: T.Type) throws -> T? {
         try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(rawBytes: $0) }
@@ -277,7 +311,7 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(littleEndian type: T.Type) throws -> T where T.RawValue: FixedWidthInteger {
         try T(littleEndianBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
@@ -290,7 +324,7 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func next<T: RawRepresentable>(bigEndian type: T.Type) throws -> T where T.RawValue: FixedWidthInteger {
         try T(bigEndianBytes: next(Bytes.self, count: MemoryLayout<T.RawValue>.size))
@@ -303,7 +337,7 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(littleEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
         try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(littleEndianBytes: $0) }
@@ -316,7 +350,7 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     @inlinable
     public mutating func nextIfPresent<T: RawRepresentable>(bigEndian type: T.Type) throws -> T? where T.RawValue: FixedWidthInteger {
         try nextIfPresent(Bytes.self, count: MemoryLayout<T.RawValue>.size).map { try T(bigEndianBytes: $0) }
@@ -495,7 +529,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete raw representable could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
@@ -511,7 +545,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete raw representable could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete raw representable could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
@@ -566,7 +600,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
@@ -582,7 +616,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
@@ -598,7 +632,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
@@ -614,7 +648,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: The type of raw representable to decode.
     /// - Returns: A raw representable type as a fixed width integer of type `type`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete integer could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/Casting/invalidMemorySize(targetSize:targetType:actualSize:)-enum.case`` if a complete integer could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif

--- a/Sources/Bytes/String.swift
+++ b/Sources/Bytes/String.swift
@@ -8,14 +8,14 @@
 //
 
 extension StringProtocol {
-    /// Get the UTF-8 representation of a string as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of a string as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         return Bytes(self.utf8)
     }
     
-    /// Initialize a String from a contiguous sequence of Bytes representing UTF-8 characters.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
+    /// Initialize a String from a contiguous sequence of ``Bytes`` representing UTF-8 characters.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
     @inlinable
     public init<Bytes: BytesCollection>(utf8Bytes: Bytes) {
         self.init(decoding: utf8Bytes, as: UTF8.self)
@@ -23,20 +23,20 @@ extension StringProtocol {
 }
 
 extension Character {
-    /// Get the UTF-8 representation of a character as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of a character as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         return Bytes(self.utf8)
     }
     
-    /// Initialize a Character from a contiguous sequence of Bytes representing a UTF-8 encoded character.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
-    /// - Throws: `BytesError.invalidCharacterByteSequence` if the byte sequence does not represent a single character.
+    /// Initialize a Character from a contiguous sequence of ``Bytes`` representing a UTF-8 encoded character.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
+    /// - Throws: ``BytesError/Character`` if the byte sequence does not represent a single character.
     @inlinable
-    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws(BytesError.Character) {
         let string = String(utf8Bytes: utf8Bytes)
         guard string.count == 1 else {
-            throw BytesError.invalidCharacterByteSequence
+            throw .invalidCharacterByteSequence
         }
         self.init(string)
     }
@@ -52,9 +52,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next(utf8 type: String.Type, count: Int) throws -> String {
+    public mutating func next(
+        utf8 type: String.Type,
+        count: Int
+    ) throws(BytesError.InvalidMemorySize) -> String {
         String(utf8Bytes: try next(Bytes.self, count: count))
     }
     
@@ -65,9 +68,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) throws -> String {
+    public mutating func next(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) throws(BytesError.InvalidMemorySize) -> String {
         String(utf8Bytes: try next(Bytes.self, min: minCount, max: maxCount))
     }
     
@@ -77,9 +84,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, count: Int) throws -> String? {
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        count: Int
+    ) throws(BytesError.InvalidMemorySize) -> String? {
         try nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
     }
     
@@ -90,9 +100,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/InvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) throws -> String? {
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) throws(BytesError.InvalidMemorySize) -> String? {
         try nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
     }
     
@@ -102,11 +116,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the character could not be identified.
     @inlinable
     public mutating func check(
         utf8 character: Character
-    ) throws {
+    ) throws(BytesError.CheckedSequenceNotFound) {
         try check(character.utf8Bytes)
     }
     
@@ -120,11 +134,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the string could not be identified.
     @inlinable
     public mutating func check<String: StringProtocol>(
         utf8 string: String
-    ) throws {
+    ) throws(BytesError.CheckedSequenceNotFound) {
         try check(string.utf8Bytes)
     }
     
@@ -135,12 +149,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the character could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
         utf8 character: Character
-    ) throws -> Bool {
+    ) throws(BytesError.CheckedSequenceNotFound) -> Bool {
         try checkIfPresent(character.utf8Bytes)
     }
     
@@ -155,12 +169,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/CheckedSequenceNotFound`` if the string could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<String: StringProtocol>(
         utf8 string: String
-    ) throws -> Bool {
+    ) throws(BytesError.CheckedSequenceNotFound) -> Bool {
         try checkIfPresent(string.utf8Bytes)
     }
 }
@@ -168,6 +182,7 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the UTF-8 encoded String of size `count`, or throws if it could not.
@@ -176,12 +191,16 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next(utf8 type: String.Type, count: Int) async throws -> String {
+    @_disfavoredOverload
+    public mutating func next(
+        utf8 type: String.Type,
+        count: Int
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> String {
         String(utf8Bytes: try await next(Bytes.self, count: count))
     }
     
@@ -192,12 +211,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String {
+    @_disfavoredOverload
+    public mutating func next(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> String {
         String(utf8Bytes: try await next(Bytes.self, min: minCount, max: maxCount))
     }
     
@@ -207,12 +231,16 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, count: Int) async throws -> String? {
+    @_disfavoredOverload
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        count: Int
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> String? {
         try await nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
     }
     
@@ -223,12 +251,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String? {
+    @_disfavoredOverload
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) async throws(BytesError.IteratedInvalidMemorySize<any Error>) -> String? {
         try await nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
     }
     
@@ -242,14 +275,15 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the string could not be identified.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<String: StringProtocol>(
         utf8 string: String
-    ) async throws {
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<any Error>) {
         try await check(string.utf8Bytes)
     }
     
@@ -264,15 +298,134 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the string could not be identified.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
     @discardableResult
+    @_disfavoredOverload
     public mutating func checkIfPresent<String: StringProtocol>(
         utf8 string: String
-    ) async throws -> Bool {
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<any Error>) -> Bool {
+        try await checkIfPresent(string.utf8Bytes)
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the UTF-8 encoded String of size `count`, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter count: The number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size `count`.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func next(
+        utf8 type: String.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> String {
+        String(utf8Bytes: try await next(Bytes.self, count: count))
+    }
+    
+    /// Asynchronously advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a string.
+    /// - Parameter maxCount: The maximum number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size at least `minCount` and at most `maxCount`.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func next(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> String {
+        String(utf8Bytes: try await next(Bytes.self, min: minCount, max: maxCount))
+    }
+    
+    /// Asynchronously advances to the UTF-8 encoded String of size `count`, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter count: The number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> String? {
+        try await nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
+    }
+    
+    /// Asynchronously advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a string.
+    /// - Parameter maxCount: The maximum number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
+    /// - Throws: ``BytesError/IteratedInvalidMemorySize`` if a complete string could not be returned by the time the sequence ended.
+    @inlinable
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedInvalidMemorySize<Failure>) -> String? {
+        try await nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded String if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the String is empty, this method won't do anything.
+    ///
+    /// - Note: The string will not check for null termination unless a null character is specified.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter string: The string to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the string could not be identified.
+    @inlinable
+    public mutating func check<String: StringProtocol>(
+        utf8 string: String,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) {
+        try await check(string.utf8Bytes)
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded String if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the String is empty, this method won't do anything.
+    ///
+    /// - Note: The string will not check for null termination unless a null character is specified.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter string: The string to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the string was found, or `false` if the sequence finished.
+    /// - Throws: ``BytesError/IteratedCheckedSequenceNotFound`` if the string could not be identified.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<String: StringProtocol>(
+        utf8 string: String,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.IteratedCheckedSequenceNotFound<Failure>) -> Bool {
         try await checkIfPresent(string.utf8Bytes)
     }
 }

--- a/Sources/Bytes/String.swift
+++ b/Sources/Bytes/String.swift
@@ -8,14 +8,14 @@
 //
 
 extension StringProtocol {
-    /// Get the UTF-8 representation of a string as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of a string as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         return Bytes(self.utf8)
     }
     
-    /// Initialize a String from a contiguous sequence of Bytes representing UTF-8 characters.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
+    /// Initialize a String from a contiguous sequence of ``Bytes`` representing UTF-8 characters.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
     @inlinable
     public init<Bytes: BytesCollection>(utf8Bytes: Bytes) {
         self.init(decoding: utf8Bytes, as: UTF8.self)
@@ -23,21 +23,20 @@ extension StringProtocol {
 }
 
 extension Character {
-    /// Get the UTF-8 representation of a character as a contiguous sequence of Bytes.
+    /// Get the UTF-8 representation of a character as a contiguous sequence of ``Bytes``.
     @inlinable
     public var utf8Bytes: Bytes {
         return Bytes(self.utf8)
     }
     
-    /// Initialize a Character from a contiguous sequence of Bytes representing a UTF-8 encoded character.
-    /// - Parameter utf8Bytes: The Bytes to interpret as a string.
-    /// - Throws: `BytesError.invalidCharacterByteSequence` if the byte sequence does not represent a single character.
+    /// Initialize a Character from a contiguous sequence of ``Bytes`` representing a UTF-8 encoded character.
+    /// - Parameter utf8Bytes: The ``Bytes`` to interpret as a string.
+    /// - Throws: ``BytesError/CharacterDecodingError/invalidCharacterByteSequence`` if the byte sequence does not represent a single character.
     @inlinable
-    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws {
+    public init<Bytes: BytesCollection>(utf8Bytes: Bytes) throws(BytesError.CharacterDecodingError) {
         let string = String(utf8Bytes: utf8Bytes)
-        guard string.count == 1 else {
-            throw BytesError.invalidCharacterByteSequence
-        }
+        guard string.count == 1
+        else { throw .invalidCharacterByteSequence }
         self.init(string)
     }
 }
@@ -52,9 +51,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next(utf8 type: String.Type, count: Int) throws -> String {
+    public mutating func next(
+        utf8 type: String.Type,
+        count: Int
+    ) throws(BytesError.BufferSizeError) -> String {
         String(utf8Bytes: try next(Bytes.self, count: count))
     }
     
@@ -65,9 +67,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) throws -> String {
+    public mutating func next(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) throws(BytesError.BufferSizeError) -> String {
         String(utf8Bytes: try next(Bytes.self, min: minCount, max: maxCount))
     }
     
@@ -77,9 +83,12 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, count: Int) throws -> String? {
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        count: Int
+    ) throws(BytesError.BufferSizeError) -> String? {
         try nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
     }
     
@@ -90,9 +99,13 @@ extension IteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) throws -> String? {
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) throws(BytesError.BufferSizeError) -> String? {
         try nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
     }
     
@@ -102,11 +115,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
     @inlinable
     public mutating func check(
         utf8 character: Character
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         try check(character.utf8Bytes)
     }
     
@@ -120,11 +133,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
     @inlinable
     public mutating func check<String: StringProtocol>(
         utf8 string: String
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         try check(string.utf8Bytes)
     }
     
@@ -135,12 +148,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter character: The character to check for.
     /// - Returns: `true` if the character was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the character could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the character could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
         utf8 character: Character
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         try checkIfPresent(character.utf8Bytes)
     }
     
@@ -155,12 +168,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent<String: StringProtocol>(
         utf8 string: String
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         try checkIfPresent(string.utf8Bytes)
     }
 }
@@ -168,6 +181,7 @@ extension IteratorProtocol where Element == Byte {
 
 // MARK: - AsyncByteIterator
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the UTF-8 encoded String of size `count`, or throws if it could not.
@@ -176,12 +190,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next(utf8 type: String.Type, count: Int) async throws -> String {
+    @_disfavoredOverload
+    public mutating func next(
+        utf8 type: String.Type,
+        count: Int
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> String {
         String(utf8Bytes: try await next(Bytes.self, count: count))
     }
     
@@ -192,12 +212,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String {
+    @_disfavoredOverload
+    public mutating func next(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> String {
         String(utf8Bytes: try await next(Bytes.self, min: minCount, max: maxCount))
     }
     
@@ -207,12 +234,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter type: This should be set to `String.self`.
     /// - Parameter count: The number of bytes to form into a string.
     /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, count: Int) async throws -> String? {
+    @_disfavoredOverload
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        count: Int
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> String? {
         try await nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
     }
     
@@ -223,12 +256,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// - Parameter minCount: The minimum number of bytes to form into a string.
     /// - Parameter maxCount: The maximum number of bytes to form into a string.
     /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if a complete string could not be returned by the time the sequence ended.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent(utf8 type: String.Type, min minCount: Int = 0, max maxCount: Int) async throws -> String? {
+    @_disfavoredOverload
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> String? {
         try await nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
     }
     
@@ -242,14 +282,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check<String: StringProtocol>(
         utf8 string: String
-    ) async throws {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
         try await check(string.utf8Bytes)
     }
     
@@ -264,15 +307,148 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter string: The string to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
     @discardableResult
+    @_disfavoredOverload
     public mutating func checkIfPresent<String: StringProtocol>(
         utf8 string: String
-    ) async throws -> Bool {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
+        try await checkIfPresent(string.utf8Bytes)
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the UTF-8 encoded String of size `count`, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter count: The number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size `count`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next(
+        utf8 type: String.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> String {
+        String(utf8Bytes: try await next(Bytes.self, count: count))
+    }
+    
+    /// Asynchronously advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a string.
+    /// - Parameter maxCount: The maximum number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size at least `minCount` and at most `maxCount`.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> String {
+        String(utf8Bytes: try await next(Bytes.self, min: minCount, max: maxCount))
+    }
+    
+    /// Asynchronously advances to the UTF-8 encoded String of size `count`, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter count: The number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size `count`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        count: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> String? {
+        try await nextIfPresent(Bytes.self, count: count).map { String(utf8Bytes: $0) }
+    }
+    
+    /// Asynchronously advances to the UTF-8 encoded String with the specified minimum size, continuing until the specified maximum size, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `String.self`.
+    /// - Parameter minCount: The minimum number of bytes to form into a string.
+    /// - Parameter maxCount: The maximum number of bytes to form into a string.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A string of size at least `minCount` and at most `maxCount`, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if a complete string could not be returned by the time the sequence ended.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent(
+        utf8 type: String.Type,
+        min minCount: Int = 0,
+        max maxCount: Int,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> String? {
+        try await nextIfPresent(Bytes.self, min: minCount, max: maxCount).map { String(utf8Bytes: $0) }
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded String if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the String is empty, this method won't do anything.
+    ///
+    /// - Note: The string will not check for null termination unless a null character is specified.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter string: The string to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check<String: StringProtocol>(
+        utf8 string: String,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        try await check(string.utf8Bytes)
+    }
+    
+    /// Asynchronously advances by the specified UTF-8 encoded String if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// If the String is empty, this method won't do anything.
+    ///
+    /// - Note: The string will not check for null termination unless a null character is specified.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter string: The string to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the string was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the string could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent<String: StringProtocol>(
+        utf8 string: String,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
         try await checkIfPresent(string.utf8Bytes)
     }
 }

--- a/Sources/Bytes/UUID.swift
+++ b/Sources/Bytes/UUID.swift
@@ -33,11 +33,13 @@ extension UUID {
     /// Initialize a UUID from a contiguous sequence of Bytes representing the 16-byte compact format.
     /// - Parameter bytes: The Bytes to interpret as a binary UUID.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not 16-bytes.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not 16-bytes.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes) throws {
-        try self.init(uuid: bytes.casting())
+    public init<Bytes: BytesCollection>(
+        bytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) {
+        self.init(uuid: try bytes.casting())
     }
     
     /// The 36-character Byte representation of a UUID.
@@ -47,14 +49,21 @@ extension UUID {
     }
     
     /// Initialize a UUID from a contiguous sequence of Bytes representing the 36-character format.
-    /// - Parameter bytes: The Bytes to interpret as a UUID string.
+    /// - Parameter stringBytes: The Bytes to interpret as a UUID string.
     /// - Throws:
-    ///     - `BytesError.invalidUUIDByteSequence` if the byte sequence does not represent a valid UUID.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not 36-bytes.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the byte sequence does not represent a valid UUID.
     @inlinable
-    public init<Bytes: BytesCollection>(stringBytes: Bytes) throws {
-        try stringBytes.canBeCasted(to: UUIDTextualBytes.self)
+    public init<Bytes: BytesCollection>(
+        stringBytes: Bytes
+    ) throws(BytesError.UUIDDecoding.BufferSizeError) {
+        do {
+            try stringBytes.canBeCasted(to: UUIDTextualBytes.self)
+        } catch {
+            throw .castingFailure(error)
+        }
         guard let value = Self(uuidString: String(utf8Bytes: stringBytes)) else {
-            throw BytesError.invalidUUIDByteSequence
+            throw .invalidUUIDByteSequence
         }
         self = value
     }
@@ -70,13 +79,19 @@ extension Collection where Element == UUID {
     }
     
     /// Initialize a collection of UUIDs with a sequence of Bytes representing the individual 16-byte UUIDs.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of binary UUIDs.
+    /// - Parameter bytes: The Bytes to interpret as a sequence of binary UUIDs.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of 16-bytes.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 16-bytes.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+    public init<Bytes: BytesCollection>(
+        bytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
     /// The 36-character Byte representations of a collection of a UUIDs.
@@ -86,14 +101,19 @@ extension Collection where Element == UUID {
     }
     
     /// Initialize a collection of UUIDs with a sequence of Bytes representing the individual 36-character UUIDs.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of binary UUIDs.
+    /// - Parameter stringBytes: The Bytes to interpret as a sequence of string UUIDs.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of 36-bytes.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidUUIDByteSequence` if the byte sequence does not represent valid UUIDs.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 36-bytes.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the byte sequence does not represent valid UUIDs.
     @inlinable
-    public init<Bytes: BytesCollection>(stringBytes: Bytes) throws where Self: RangeReplaceableCollection {
-        try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, mapping: Element.init(stringBytes:))
+    public init<Bytes: BytesCollection>(
+        stringBytes: Bytes
+    ) throws(BytesError.UUIDDecoding.BufferSizeError) where Self: RangeReplaceableCollection {
+        do {
+            try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, mapping: Element.init(stringBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
@@ -101,24 +121,35 @@ extension Collection where Element == UUID {
 
 extension Set where Element == UUID {
     /// Initialize a Set of UUIDs with a sequence of Bytes representing the individual 16-byte UUIDs.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of binary UUIDs.
+    /// - Parameter bytes: The Bytes to interpret as a sequence of binary UUIDs.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of 16-bytes.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 16-bytes.
+    ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if the byte sequence cannot be made to be contiguous.
     @inlinable
-    public init<Bytes: BytesCollection>(bytes: Bytes) throws {
-        try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+    public init<Bytes: BytesCollection>(
+        bytes: Bytes
+    ) throws(BytesError.ContiguousBytes.BufferSizeError) {
+        do {
+            try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+        } catch {
+            throw error.flattened
+        }
     }
     
     /// Initialize a Set of UUIDs with a sequence of Bytes representing the individual 36-character UUIDs.
-    /// - Parameter rawBytes: The Bytes to interpret as a sequence of binary UUIDs.
+    /// - Parameter stringBytes: The Bytes to interpret as a sequence of string UUIDs.
     /// - Throws:
-    ///     - `BytesError.invalidMemorySize` if the byte sequence is not a multiple of 36-bytes.
-    ///     - `BytesError.contiguousMemoryUnavailable` if the byte sequence cannot be made to be contiguous.
-    ///     - `BytesError.invalidUUIDByteSequence` if the byte sequence does not represent valid UUIDs.
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 36-bytes.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the byte sequence does not represent valid UUIDs.
     @inlinable
-    public init<Bytes: BytesCollection>(stringBytes: Bytes) throws {
-        try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, mapping: Element.init(stringBytes:))
+    public init<Bytes: BytesCollection>(
+        stringBytes: Bytes
+    ) throws(BytesError.UUIDDecoding.BufferSizeError) {
+        do {
+            try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, mapping: Element.init(stringBytes:))
+        } catch {
+            throw error.flattened
+        }
     }
 }
 
@@ -131,10 +162,13 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID.
-    /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 16 bytes are not available.
     @inlinable
-    public mutating func next(_ type: UUID.Type) throws -> UUID {
-        try UUID(bytes: next(Bytes.self, count: MemoryLayout<uuid_t>.size))
+    public mutating func next(
+        _ type: UUID.Type
+    ) throws(BytesError.BufferSizeError) -> UUID {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! UUID(bytes: try next(Bytes.self, count: MemoryLayout<uuid_t>.size))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -142,10 +176,20 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID.
-    /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 36 bytes are not available.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the bytes could not be decoded into a UUID.
     @inlinable
-    public mutating func next(string type: UUID.Type) throws -> UUID {
-        try UUID(stringBytes: next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
+    public mutating func next(
+        string type: UUID.Type
+    ) throws(BytesError.UUIDDecoding.BufferSizeError) -> UUID {
+        let stringBytes: Bytes
+        do {
+            stringBytes = try next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        return try UUID(stringBytes: stringBytes)
     }
     
     /// Asynchronously advances to the next binary UUID, or ends the sequence if there is no next element.
@@ -153,10 +197,14 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
+    /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 16 bytes are not available.
     @inlinable
-    public mutating func nextIfPresent(_ type: UUID.Type) throws -> UUID? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
+    public mutating func nextIfPresent(
+        _ type: UUID.Type
+    ) throws(BytesError.BufferSizeError) -> UUID? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size)
+            .map { try! UUID(bytes: $0) }
     }
     
     /// Asynchronously advances to the next UUID String, or ends the sequence if there is no next element.
@@ -164,10 +212,21 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 36 bytes are not available.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the bytes could not be decoded into a UUID.
     @inlinable
-    public mutating func nextIfPresent(string type: UUID.Type) throws -> UUID? {
-        try nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
+    public mutating func nextIfPresent(
+        string type: UUID.Type
+    ) throws(BytesError.UUIDDecoding.BufferSizeError) -> UUID? {
+        let stringBytes: Bytes?
+        do {
+            stringBytes = try nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+        } catch {
+            throw .castingFailure(error)
+        }
+        guard let stringBytes else { return nil }
+        return try UUID(stringBytes: stringBytes)
     }
     
     /// Advances by the specified binary UUID if found, or throws if the next bytes in the iterator do not match.
@@ -176,11 +235,11 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
     @inlinable
     public mutating func check(
         _ uuid: UUID
-    ) throws {
+    ) throws(BytesError.SequenceCheckError) {
         try check(uuid.bytes)
     }
     
@@ -190,15 +249,13 @@ extension IteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
     @inlinable
     public mutating func check(
         string uuid: UUID
-    ) throws {
-        let value = try next(string: UUID.self)
-        
-        guard value == uuid
-        else { throw BytesError.checkedSequenceNotFound }
+    ) throws(BytesError.SequenceCheckError) {
+        guard try checkIfPresent(string: uuid)
+        else { throw .checkedSequenceNotFound }
     }
     
     /// Advances by the specified binary UUID if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
@@ -208,12 +265,12 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
         _ uuid: UUID
-    ) throws -> Bool {
+    ) throws(BytesError.SequenceCheckError) -> Bool {
         try checkIfPresent(uuid.bytes)
     }
     
@@ -224,24 +281,31 @@ extension IteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws: ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
         string uuid: UUID
-    ) throws -> Bool {
-        guard let value = try nextIfPresent(string: UUID.self) else { return false }
+    ) throws(BytesError.SequenceCheckError) -> Bool {
+        let value: UUID?
+        do {
+            value = try nextIfPresent(string: UUID.self)
+        } catch {
+            throw .checkedSequenceNotFound
+        }
         
-        guard value == uuid
-        else { throw BytesError.checkedSequenceNotFound }
-        
-        return true
+        switch value {
+        case .none: return false
+        case uuid:  return true
+        case .some: throw .checkedSequenceNotFound
+        }
     }
 }
 
 
 // MARK: - AsyncByteIterator
 
+#if canImport(Darwin)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol where Element == Byte {
     /// Asynchronously advances to the next binary UUID, or throws if it could not.
@@ -249,13 +313,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID.
-    /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 16 bytes are not available.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next(_ type: UUID.Type) async throws -> UUID {
-        try UUID(bytes: await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
+    @_disfavoredOverload
+    public mutating func next(
+        _ type: UUID.Type
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> UUID {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! UUID(bytes: try await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -263,13 +333,29 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID.
-    /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 36 bytes are not available.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the bytes could not be decoded into a UUID.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func next(string type: UUID.Type) async throws -> UUID {
-        try UUID(stringBytes: await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size))
+    @_disfavoredOverload
+    public mutating func next(
+        string type: UUID.Type
+    ) async throws(BytesError.Iteration<any Error>.UUIDDecoding.BufferSizeError) -> UUID {
+        let stringBytes: Bytes
+        do {
+            stringBytes = try await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try UUID(stringBytes: stringBytes)
+        } catch {
+            throw .castingFailure(error)
+        }
     }
     
     /// Asynchronously advances to the next binary UUID, or ends the sequence if there is no next element.
@@ -277,13 +363,20 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if 16 bytes are not available.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 16 bytes are not available.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent(_ type: UUID.Type) async throws -> UUID? {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size).map { try UUID(bytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent(
+        _ type: UUID.Type
+    ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> UUID? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size)
+            .map { try! UUID(bytes: $0) }
     }
     
     /// Asynchronously advances to the next UUID String, or ends the sequence if there is no next element.
@@ -291,13 +384,30 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter type: This should be set to `UUID.self`.
     /// - Returns: A UUID, or `nil` if the sequence is finished.
-    /// - Throws: `BytesError.invalidMemorySize` if 36 bytes are not available.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 36 bytes are not available.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the bytes could not be decoded into a UUID.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
-    public mutating func nextIfPresent(string type: UUID.Type) async throws -> UUID? {
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size).map { try UUID(stringBytes: $0) }
+    @_disfavoredOverload
+    public mutating func nextIfPresent(
+        string type: UUID.Type
+    ) async throws(BytesError.Iteration<any Error>.UUIDDecoding.BufferSizeError) -> UUID? {
+        let stringBytes: Bytes?
+        do {
+            stringBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let stringBytes else { return nil }
+        do {
+            return try UUID(stringBytes: stringBytes)
+        } catch {
+            throw .castingFailure(error)
+        }
     }
     
     /// Asynchronously advances by the specified binary UUID if found, or throws if the next bytes in the iterator do not match.
@@ -306,14 +416,17 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check(
         _ uuid: UUID
-    ) async throws {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
         try await check(uuid.bytes)
     }
     
@@ -323,18 +436,19 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     public mutating func check(
         string uuid: UUID
-    ) async throws {
-        let value = try await next(string: UUID.self)
-        
-        guard value == uuid
-        else { throw BytesError.checkedSequenceNotFound }
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
+        guard try await checkIfPresent(string: uuid)
+        else { throw .checkedSequenceNotFound }
     }
     
     /// Asynchronously advances by the specified binary UUID if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
@@ -344,15 +458,18 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent(
         _ uuid: UUID
-    ) async throws -> Bool {
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
         try await checkIfPresent(uuid.bytes)
     }
     
@@ -363,20 +480,215 @@ extension AsyncIteratorProtocol where Element == Byte {
     /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
     /// - Parameter uuid: The UUID to check for.
     /// - Returns: `true` if the string was found, or `false` if the sequence finished.
-    /// - Throws: ``BytesError/checkedSequenceNotFound`` if the string could not be identified.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     #if swift(>=6.2)
     @concurrent
     #endif
     @inlinable
+    @_disfavoredOverload
     @discardableResult
     public mutating func checkIfPresent(
         string uuid: UUID
-    ) async throws -> Bool {
-        guard let value = try await nextIfPresent(string: UUID.self) else { return false }
+    ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
+        let value: UUID?
+        do {
+            value = try await nextIfPresent(string: UUID.self)
+        } catch {
+            throw error.mapCastingFailure { _ in .checkedSequenceNotFound }
+        }
         
-        guard value == uuid
-        else { throw BytesError.checkedSequenceNotFound }
+        switch value {
+        case .none: return false
+        case uuid:  return true
+        case .some: throw .checkedSequenceNotFound
+        }
+    }
+}
+#endif // canImport(Darwin)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension AsyncIteratorProtocol where Element == Byte {
+    /// Asynchronously advances to the next binary UUID, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `UUID.self`.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A UUID.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 16 bytes are not available.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next(
+        _ type: UUID.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> UUID {
+        /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
+        try! UUID(bytes: try await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
+    }
+    
+    /// Asynchronously advances to the next UUID String, or throws if it could not.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `UUID.self`.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A UUID.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 36 bytes are not available.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the bytes could not be decoded into a UUID.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func next(
+        string type: UUID.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.UUIDDecoding.BufferSizeError) -> UUID {
+        let stringBytes: Bytes
+        do {
+            stringBytes = try await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        do {
+            return try UUID(stringBytes: stringBytes)
+        } catch {
+            throw .castingFailure(error)
+        }
+    }
+    
+    /// Asynchronously advances to the next binary UUID, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `UUID.self`.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A UUID, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 16 bytes are not available.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent(
+        _ type: UUID.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> UUID? {
+        /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size)
+            .map { try! UUID(bytes: $0) }
+    }
+    
+    /// Asynchronously advances to the next UUID String, or ends the sequence if there is no next element.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter type: This should be set to `UUID.self`.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: A UUID, or `nil` if the sequence is finished.
+    /// - Throws:
+    ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if 36 bytes are not available.
+    ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the bytes could not be decoded into a UUID.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func nextIfPresent(
+        string type: UUID.Type,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.UUIDDecoding.BufferSizeError) -> UUID? {
+        let stringBytes: Bytes?
+        do {
+            stringBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+        } catch {
+            throw error.mapCastingFailure { .castingFailure($0) }
+        }
+        guard let stringBytes else { return nil }
+        do {
+            return try UUID(stringBytes: stringBytes)
+        } catch {
+            throw .castingFailure(error)
+        }
+    }
+    
+    /// Asynchronously advances by the specified binary UUID if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a binary UUID to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter uuid: The UUID to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check(
+        _ uuid: UUID,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        try await check(uuid.bytes)
+    }
+    
+    /// Asynchronously advances by the specified UUID String if found, or throws if the next bytes in the iterator do not match.
+    ///
+    /// Use this method when you expect a UUID String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter uuid: The UUID to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    public mutating func check(
+        string uuid: UUID,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
+        guard try await checkIfPresent(string: uuid)
+        else { throw .checkedSequenceNotFound }
+    }
+    
+    /// Asynchronously advances by the specified binary UUID if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a binary UUID to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter uuid: The UUID to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the string was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent(
+        _ uuid: UUID,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
+        try await checkIfPresent(uuid.bytes)
+    }
+    
+    /// Asynchronously advances by the specified UUID String if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
+    ///
+    /// Use this method when you expect a UUID String to be next in the sequence, and it would be an error if something else were encountered.
+    ///
+    /// **Learn More:** [Integration with AsyncSequenceReader](https://github.com/mochidev/AsyncSequenceReader#integration-with-bytes)
+    /// - Parameter uuid: The UUID to check for.
+    /// - Parameter actor: The isolation context to run the reciever on.
+    /// - Returns: `true` if the string was found, or `false` if the sequence finished.
+    /// - Throws:
+    ///     - ``BytesError/SequenceCheckError/checkedSequenceNotFound`` if the UUID could not be identified.
+    ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
+    @inlinable
+    @discardableResult
+    public mutating func checkIfPresent(
+        string uuid: UUID,
+        isolation actor: isolated (any Actor)? = #isolation
+    ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
+        let value: UUID?
+        do {
+            value = try await nextIfPresent(string: UUID.self)
+        } catch {
+            throw error.mapCastingFailure { _ in .checkedSequenceNotFound }
+        }
         
-        return true
+        switch value {
+        case .none: return false
+        case uuid:  return true
+        case .some: throw .checkedSequenceNotFound
+        }
     }
 }

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -18,8 +18,8 @@ extension BytesError {
         actualSize: @autoclosure () throws -> Int,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
@@ -27,8 +27,20 @@ extension BytesError {
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
             XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
+        } else if let invalidMemorySizeError = expressionResult as? BytesError.InvalidMemorySize {
+            XCTAssertEqual(invalidMemorySizeError.targetSize, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.targetType, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.actualSize, try actualSize(), messageResult, file: (file), line: line)
+        } else if case BytesError.IteratedInvalidMemorySize<any Error>.consumptionFailure(let invalidMemorySizeError) = expressionResult {
+            XCTAssertEqual(invalidMemorySizeError.targetSize, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.targetType, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.actualSize, try actualSize(), messageResult, file: (file), line: line)
+        } else if case BytesError.IteratedInvalidMemorySize<Never>.consumptionFailure(let invalidMemorySizeError) = expressionResult {
+            XCTAssertEqual(invalidMemorySizeError.targetSize, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.targetType, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.actualSize, try actualSize(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
+            XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
         } else {
             XCTFail(messageResult, file: (file), line: line)
         }
@@ -39,15 +51,15 @@ extension BytesError {
         collectionType: @autoclosure () throws -> String,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
         if case let Self.contiguousMemoryUnavailable(a1) = expressionResult {
             XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
+            XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
         } else {
             XCTFail(messageResult, file: (file), line: line)
         }
@@ -57,14 +69,14 @@ extension BytesError {
         _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
         if case Self.invalidCharacterByteSequence = expressionResult {
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
+            XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
         } else {
             XCTFail(messageResult, file: (file), line: line)
         }
@@ -74,14 +86,14 @@ extension BytesError {
         _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
         if case Self.invalidRawRepresentableByteSequence = expressionResult {
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
+            XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
         } else {
             XCTFail(messageResult, file: (file), line: line)
         }
@@ -91,14 +103,14 @@ extension BytesError {
         _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
         if case Self.invalidUUIDByteSequence = expressionResult {
         } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)
+            XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)
         } else {
             XCTFail(messageResult, file: (file), line: line)
         }

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -72,7 +72,8 @@ extension BytesError {
         let messageResult = message()
         
         switch expressionResult {
-        case Self.invalidCharacterByteSequence: break
+        case BytesError.CharacterDecodingError.invalidCharacterByteSequence:
+            break
         default:
             if messageResult.isEmpty {
                 XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -24,7 +24,10 @@ extension BytesError {
         let messageResult = message()
         
         switch expressionResult {
-        case let Self.invalidMemorySize(a1, a2, a3):
+        case
+            let BytesError.BufferSizeError.invalidBufferSize(a1, a2, a3),
+            let BytesError.ContiguousBytes.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
+            let BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)):
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
             XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
@@ -48,7 +51,7 @@ extension BytesError {
         let messageResult = message()
         
         switch expressionResult {
-        case let Self.contiguousMemoryUnavailable(a1):
+        case let BytesError.ContiguousBytes.BufferSizeError.contiguousBytesUnavailable(a1):
             XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
         default:
             if messageResult.isEmpty {
@@ -89,7 +92,10 @@ extension BytesError {
         let messageResult = message()
         
         switch expressionResult {
-        case Self.invalidRawRepresentableByteSequence: break
+        case
+            Self.invalidRawRepresentableByteSequence,
+            BytesError.Transformation<any Error>.BufferSizeError.transformationFailure(Self.invalidRawRepresentableByteSequence):
+            break
         default:
             if messageResult.isEmpty {
                 XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
@@ -109,7 +115,10 @@ extension BytesError {
         let messageResult = message()
         
         switch expressionResult {
-        case Self.invalidUUIDByteSequence: break
+        case
+            Self.invalidUUIDByteSequence,
+            BytesError.Transformation<any Error>.BufferSizeError.transformationFailure(Self.invalidUUIDByteSequence):
+            break
         default:
             if messageResult.isEmpty {
                 XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -18,19 +18,22 @@ extension BytesError {
         actualSize: @autoclosure () throws -> Int,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
-        if case let Self.invalidMemorySize(a1, a2, a3) = expressionResult {
+        switch expressionResult {
+        case let Self.invalidMemorySize(a1, a2, a3):
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
             XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
-        } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
-        } else {
-            XCTFail(messageResult, file: (file), line: line)
+        default:
+            if messageResult.isEmpty {
+                XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
+            } else {
+                XCTFail(messageResult, file: (file), line: line)
+            }
         }
     }
     
@@ -39,17 +42,20 @@ extension BytesError {
         collectionType: @autoclosure () throws -> String,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
-        if case let Self.contiguousMemoryUnavailable(a1) = expressionResult {
+        switch expressionResult {
+        case let Self.contiguousMemoryUnavailable(a1):
             XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
-        } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
-        } else {
-            XCTFail(messageResult, file: (file), line: line)
+        default:
+            if messageResult.isEmpty {
+                XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
+            } else {
+                XCTFail(messageResult, file: (file), line: line)
+            }
         }
     }
     
@@ -57,16 +63,19 @@ extension BytesError {
         _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
-        if case Self.invalidCharacterByteSequence = expressionResult {
-        } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
-        } else {
-            XCTFail(messageResult, file: (file), line: line)
+        switch expressionResult {
+        case Self.invalidCharacterByteSequence: break
+        default:
+            if messageResult.isEmpty {
+                XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
+            } else {
+                XCTFail(messageResult, file: (file), line: line)
+            }
         }
     }
     
@@ -74,16 +83,19 @@ extension BytesError {
         _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
-        if case Self.invalidRawRepresentableByteSequence = expressionResult {
-        } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
-        } else {
-            XCTFail(messageResult, file: (file), line: line)
+        switch expressionResult {
+        case Self.invalidRawRepresentableByteSequence: break
+        default:
+            if messageResult.isEmpty {
+                XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
+            } else {
+                XCTFail(messageResult, file: (file), line: line)
+            }
         }
     }
     
@@ -91,16 +103,19 @@ extension BytesError {
         _ expression: @autoclosure () throws -> any Error,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
-        line: UInt = #line) rethrows {
-        
+        line: UInt = #line
+    ) rethrows {
         let expressionResult = try expression()
         let messageResult = message()
         
-        if case Self.invalidUUIDByteSequence = expressionResult {
-        } else if messageResult.isEmpty {
-            XCTFail("\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)
-        } else {
-            XCTFail(messageResult, file: (file), line: line)
+        switch expressionResult {
+        case Self.invalidUUIDByteSequence: break
+        default:
+            if messageResult.isEmpty {
+                XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)
+            } else {
+                XCTFail(messageResult, file: (file), line: line)
+            }
         }
     }
 }

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -140,6 +140,10 @@ extension BytesError {
         } else if case BytesError.RawRepresentable<Never>.invalidRawRepresentableByteSequence = expressionResult {
         } else if case BytesError.RawRepresentableCasting.invalidRawRepresentableByteSequence = expressionResult {
         } else if case BytesError.RawRepresentableCharacter.invalidRawRepresentableByteSequence = expressionResult {
+        } else if case BytesError.IteratedRawRepresentableCasting<Never>.consumptionFailure(.invalidRawRepresentableByteSequence) = expressionResult {
+        } else if case BytesError.TransformedRawRepresentableCasting<Never>.consumptionFailure(.invalidRawRepresentableByteSequence) = expressionResult {
+        } else if case BytesError.IteratedRawRepresentableCasting<any Error>.consumptionFailure(.invalidRawRepresentableByteSequence) = expressionResult {
+        } else if case BytesError.TransformedRawRepresentableCasting<any Error>.consumptionFailure(.invalidRawRepresentableByteSequence) = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
         } else {

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -27,6 +27,7 @@ extension BytesError {
         case
             let BytesError.BufferSizeError.invalidBufferSize(a1, a2, a3),
             let BytesError.ContiguousBytes.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
+            let BytesError.UUIDDecoding.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
             let BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)):
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
@@ -117,8 +118,8 @@ extension BytesError {
         
         switch expressionResult {
         case
-            Self.invalidUUIDByteSequence,
-            BytesError.Transformation<any Error>.BufferSizeError.transformationFailure(Self.invalidUUIDByteSequence):
+            BytesError.UUIDDecodingError<Never>.invalidUUIDByteSequence,
+            BytesError.UUIDDecodingError<BufferSizeError>.invalidUUIDByteSequence:
             break
         default:
             if messageResult.isEmpty {

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -111,6 +111,7 @@ extension BytesError {
         let messageResult = message()
         
         if case Self.invalidCharacterByteSequence = expressionResult {
+        } else if expressionResult is BytesError.Character {
         } else if case BytesError.TransformedInvalidMemorySize<any Error>.transformationFailure(Self.invalidCharacterByteSequence) = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -39,6 +39,34 @@ extension BytesError {
             XCTAssertEqual(invalidMemorySizeError.targetSize, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(invalidMemorySizeError.targetType, try targetType(), messageResult, file: (file), line: line)
             XCTAssertEqual(invalidMemorySizeError.actualSize, try actualSize(), messageResult, file: (file), line: line)
+        } else if case BytesError.TransformedInvalidMemorySize<any Error>.consumptionFailure(let invalidMemorySizeError) = expressionResult {
+            XCTAssertEqual(invalidMemorySizeError.targetSize, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.targetType, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.actualSize, try actualSize(), messageResult, file: (file), line: line)
+        } else if case BytesError.TransformedInvalidMemorySize<Never>.consumptionFailure(let invalidMemorySizeError) = expressionResult {
+            XCTAssertEqual(invalidMemorySizeError.targetSize, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.targetType, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(invalidMemorySizeError.actualSize, try actualSize(), messageResult, file: (file), line: line)
+        } else if case let BytesError.Casting.invalidMemorySize(a1, a2, a3) = expressionResult {
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
+        } else if case let BytesError.IteratedCasting<any Error>.consumptionFailure(.invalidMemorySize(a1, a2, a3)) = expressionResult {
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
+        } else if case let BytesError.IteratedCasting<Never>.consumptionFailure(.invalidMemorySize(a1, a2, a3)) = expressionResult {
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
+        } else if case let BytesError.TransformedCasting<any Error>.consumptionFailure(.invalidMemorySize(a1, a2, a3)) = expressionResult {
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
+        } else if case let BytesError.TransformedCasting<Never>.consumptionFailure(.invalidMemorySize(a1, a2, a3)) = expressionResult {
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
         } else {
@@ -58,6 +86,14 @@ extension BytesError {
         
         if case let Self.contiguousMemoryUnavailable(a1) = expressionResult {
             XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
+        } else if case let BytesError.Casting.contiguousMemoryUnavailable(a1) = expressionResult {
+            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
+        } else if case let BytesError.IteratedCasting<any Error>.consumptionFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {
+            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
+        } else if case let BytesError.IteratedCasting<Never>.consumptionFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
+        } else if case let BytesError.TransformedCasting<any Error>.consumptionFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {
+            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
+        } else if case let BytesError.TransformedCasting<Never>.consumptionFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
         } else {
@@ -75,6 +111,7 @@ extension BytesError {
         let messageResult = message()
         
         if case Self.invalidCharacterByteSequence = expressionResult {
+        } else if case BytesError.TransformedInvalidMemorySize<any Error>.transformationFailure(Self.invalidCharacterByteSequence) = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
         } else {
@@ -92,6 +129,7 @@ extension BytesError {
         let messageResult = message()
         
         if case Self.invalidRawRepresentableByteSequence = expressionResult {
+        } else if case BytesError.TransformedInvalidMemorySize<any Error>.transformationFailure(Self.invalidRawRepresentableByteSequence) = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
         } else {
@@ -109,6 +147,7 @@ extension BytesError {
         let messageResult = message()
         
         if case Self.invalidUUIDByteSequence = expressionResult {
+        } else if case BytesError.TransformedInvalidMemorySize<any Error>.transformationFailure(Self.invalidUUIDByteSequence) = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidUUIDByteSequence", file: (file), line: line)
         } else {

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -67,6 +67,10 @@ extension BytesError {
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
             XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
+        } else if case let BytesError.RawRepresentableCasting.castingFailure(.invalidMemorySize(a1, a2, a3)) = expressionResult {
+            XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
+            XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
         } else {
@@ -94,6 +98,7 @@ extension BytesError {
         } else if case let BytesError.TransformedCasting<any Error>.consumptionFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {
             XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
         } else if case let BytesError.TransformedCasting<Never>.consumptionFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
+        } else if case let BytesError.RawRepresentableCasting.castingFailure(.contiguousMemoryUnavailable(a1)) = expressionResult {            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
         } else {
@@ -113,6 +118,7 @@ extension BytesError {
         if case Self.invalidCharacterByteSequence = expressionResult {
         } else if expressionResult is BytesError.Character {
         } else if case BytesError.TransformedInvalidMemorySize<any Error>.transformationFailure(Self.invalidCharacterByteSequence) = expressionResult {
+        } else if case BytesError.RawRepresentableCharacter.castingFailure(.invalidCharacterByteSequence) = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidCharacterByteSequence", file: (file), line: line)
         } else {
@@ -131,6 +137,9 @@ extension BytesError {
         
         if case Self.invalidRawRepresentableByteSequence = expressionResult {
         } else if case BytesError.TransformedInvalidMemorySize<any Error>.transformationFailure(Self.invalidRawRepresentableByteSequence) = expressionResult {
+        } else if case BytesError.RawRepresentable<Never>.invalidRawRepresentableByteSequence = expressionResult {
+        } else if case BytesError.RawRepresentableCasting.invalidRawRepresentableByteSequence = expressionResult {
+        } else if case BytesError.RawRepresentableCharacter.invalidRawRepresentableByteSequence = expressionResult {
         } else if messageResult.isEmpty {
             XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidRawRepresentableByteSequence", file: (file), line: line)
         } else {

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -28,6 +28,7 @@ extension BytesError {
             let BytesError.BufferSizeError.invalidBufferSize(a1, a2, a3),
             let BytesError.ContiguousBytes.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
             let BytesError.UUIDDecoding.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
+            let BytesError.RawRepresentable.ContiguousBytes.BufferSizeError.castingFailure(.castingFailure(.invalidBufferSize(a1, a2, a3))),
             let BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)):
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
@@ -73,7 +74,9 @@ extension BytesError {
         let messageResult = message()
         
         switch expressionResult {
-        case BytesError.CharacterDecodingError.invalidCharacterByteSequence:
+        case
+            BytesError.CharacterDecodingError.invalidCharacterByteSequence,
+            BytesError.RawRepresentable.CharacterDecodingError.castingFailure(.invalidCharacterByteSequence):
             break
         default:
             if messageResult.isEmpty {
@@ -95,8 +98,9 @@ extension BytesError {
         
         switch expressionResult {
         case
-            Self.invalidRawRepresentableByteSequence,
-            BytesError.Transformation<any Error>.BufferSizeError.transformationFailure(Self.invalidRawRepresentableByteSequence):
+            BytesError.RawRepresentableError<Never>.invalidRawRepresentableByteSequence,
+            BytesError.RawRepresentable.CharacterDecodingError.invalidRawRepresentableByteSequence,
+            BytesError.RawRepresentable.ContiguousBytes.BufferSizeError.invalidRawRepresentableByteSequence:
             break
         default:
             if messageResult.isEmpty {


### PR DESCRIPTION
- Updated documentation for `BytesCollection`
- Updated `AsyncByteIterator` and `AsyncChunkedBytes` to support typed throws
- Updated test helper functions
- Updated `ByteIterator` to support typed throws
- Updated `Collection` casting to support typed throws
- Removed overload that could be satisfied by a default value
- Updated `Integer` casting to support typed throws
- Updated `String` casting to support typed throws
- Updated `UUID` casting to support typed throws
- Updated `RawRepresentable` casting to support typed throws