### PR TITLE
Broader Default `ByteCollection` Conformance

### DIFF
--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -10,7 +10,7 @@
 public typealias Byte = UInt8
 
 /// A type that has the same API as ``Bytes``, ``BytesSlice``, and ``ContiguousBytes``.
-public protocol BytesCollection: CustomDebugStringConvertible, CustomReflectable, CustomStringConvertible, ExpressibleByArrayLiteral, MutableCollection, RandomAccessCollection, RangeReplaceableCollection, Sendable where Element == Byte, Index == Int, SubSequence: BytesCollection {}
+public protocol BytesCollection: Collection where Element == Byte, Index == Int, SubSequence: BytesCollection {}
 
 /// A collection that supports contiguous reads of its underlying storage
 public protocol ContiguousBytesCollection: BytesCollection where Element == Byte {

--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -54,3 +54,10 @@ import FoundationEssentials
 
 extension Data: BytesCollection, ContiguousBytesCollection {}
 #endif
+
+#if canImport(Dispatch)
+import Dispatch
+
+extension DispatchData: BytesCollection {}
+extension DispatchData.Region: BytesCollection, ContiguousBytesCollection {}
+#endif

--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -25,9 +25,6 @@ extension Bytes: BytesCollection, ContiguousBytesCollection {}
 public typealias BytesSlice = ArraySlice<Byte>
 extension BytesSlice: BytesCollection, ContiguousBytesCollection {}
 
-public typealias ContiguousBytes = ContiguousArray<Byte>
-extension ContiguousBytes: BytesCollection, ContiguousBytesCollection {}
-
 extension Slice: BytesCollection where Base: BytesCollection {}
 extension Slice: ContiguousBytesCollection where Base: ContiguousBytesCollection, Index == Int {
     @inlinable
@@ -38,6 +35,7 @@ extension Slice: ContiguousBytesCollection where Base: ContiguousBytesCollection
     }
 }
 
+extension ContiguousArray<Byte>: BytesCollection, ContiguousBytesCollection {}
 extension EmptyCollection<Byte>: BytesCollection, ContiguousBytesCollection {}
 extension CollectionOfOne<Byte>: BytesCollection, ContiguousBytesCollection {}
 extension UnsafeBufferPointer<Byte>: BytesCollection, ContiguousBytesCollection {}

--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -44,3 +44,13 @@ extension UnsafeBufferPointer<Byte>: BytesCollection, ContiguousBytesCollection 
 extension UnsafeMutableBufferPointer<Byte>: BytesCollection, ContiguousBytesCollection {}
 extension UnsafeRawBufferPointer: BytesCollection, ContiguousBytesCollection {}
 extension UnsafeMutableRawBufferPointer: BytesCollection, ContiguousBytesCollection {}
+
+#if canImport(Foundation) || canImport(FoundationEssentials)
+#if canImport(Foundation)
+import Foundation
+#else
+import FoundationEssentials
+#endif
+
+extension Data: BytesCollection, ContiguousBytesCollection {}
+#endif

--- a/Sources/Bytes/Bytes.swift
+++ b/Sources/Bytes/Bytes.swift
@@ -27,3 +27,20 @@ extension BytesSlice: BytesCollection, ContiguousBytesCollection {}
 
 public typealias ContiguousBytes = ContiguousArray<Byte>
 extension ContiguousBytes: BytesCollection, ContiguousBytesCollection {}
+
+extension Slice: BytesCollection where Base: BytesCollection {}
+extension Slice: ContiguousBytesCollection where Base: ContiguousBytesCollection, Index == Int {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try base.withUnsafeBytes { rawBufferPointer in
+            try body(UnsafeRawBufferPointer(rebasing: rawBufferPointer[self.startIndex..<self.endIndex]))
+        }
+    }
+}
+
+extension EmptyCollection<Byte>: BytesCollection, ContiguousBytesCollection {}
+extension CollectionOfOne<Byte>: BytesCollection, ContiguousBytesCollection {}
+extension UnsafeBufferPointer<Byte>: BytesCollection, ContiguousBytesCollection {}
+extension UnsafeMutableBufferPointer<Byte>: BytesCollection, ContiguousBytesCollection {}
+extension UnsafeRawBufferPointer: BytesCollection, ContiguousBytesCollection {}
+extension UnsafeMutableRawBufferPointer: BytesCollection, ContiguousBytesCollection {}

--- a/Sources/Bytes/UUID.swift
+++ b/Sources/Bytes/UUID.swift
@@ -98,7 +98,7 @@ extension Collection where Element == UUID {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 16-bytes.
     @inlinable
-    public init<Bytes: BytesCollection>(
+    public init<Bytes: BytesCollection & Sendable>(
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) where Self: RangeReplaceableCollection {
         do {
@@ -113,7 +113,7 @@ extension Collection where Element == UUID {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 16-bytes.
     @inlinable
-    public init<Bytes: BytesCollection>(
+    public init<Bytes: BytesCollection & Sendable>(
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) where Self: RangeReplaceableCollection, Bytes.SubSequence: ContiguousBytesCollection {
         do {
@@ -135,7 +135,7 @@ extension Collection where Element == UUID {
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 36-bytes.
     ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the byte sequence does not represent valid UUIDs.
     @inlinable
-    public init<Bytes: BytesCollection>(
+    public init<Bytes: BytesCollection & Sendable>(
         stringBytes: Bytes
     ) throws(BytesError.UUIDDecoding.BufferSizeError) where Self: RangeReplaceableCollection {
         do {
@@ -154,7 +154,7 @@ extension Set where Element == UUID {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 16-bytes.
     @inlinable
-    public init<Bytes: BytesCollection>(
+    public init<Bytes: BytesCollection & Sendable>(
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) {
         do {
@@ -169,7 +169,7 @@ extension Set where Element == UUID {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 16-bytes.
     @inlinable
-    public init<Bytes: BytesCollection>(
+    public init<Bytes: BytesCollection & Sendable>(
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) where Bytes.SubSequence: ContiguousBytesCollection {
         do {
@@ -185,7 +185,7 @@ extension Set where Element == UUID {
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the byte sequence is not a multiple of 36-bytes.
     ///     - ``BytesError/UUIDDecodingError/invalidUUIDByteSequence`` if the byte sequence does not represent valid UUIDs.
     @inlinable
-    public init<Bytes: BytesCollection>(
+    public init<Bytes: BytesCollection & Sendable>(
         stringBytes: Bytes
     ) throws(BytesError.UUIDDecoding.BufferSizeError) {
         do {

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -142,7 +142,6 @@ final class BytesTests: XCTestCase {
         XCTAssertTrue(Byte.self == UInt8.self)
         XCTAssertTrue(Bytes.self == Array<UInt8>.self)
         XCTAssertTrue(BytesSlice.self == ArraySlice<UInt8>.self)
-        XCTAssertTrue(ContiguousBytes.self == ContiguousArray<UInt8>.self)
         
         XCTAssertFalse(Byte.self == Int8.self)
         XCTAssertFalse(Bytes.self == Array<Int8>.self)


### PR DESCRIPTION
- Updated `BytesCollection` requirements to be more lax
- Added `ByteCollection` conformance to other Swift buit-in byte collection types
- Added `ByteCollection` conformance to `Data`
- Added `ByteCollection` conformance to `DispatchData`
- Removed `ContiguousBytes` typealias since it conflicts with Foundation's protocol