### PR TITLE
Casting Error Type Improvements

### DIFF
--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -99,7 +99,7 @@ extension Collection where Element == Byte {
         let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: elementSize)
         
         guard remainingElementSize == 0 else {
-            throw .invalidBufferSize(targetSize: (elementCount+1)*elementSize, targetType: "\(Element.self)", actualSize: numberOfBytes)
+            throw .invalidBufferSize(targetSize: (elementCount + 1)*elementSize, targetType: "\(Element.self)<\(elementCount + 1)>", actualSize: numberOfBytes)
         }
         
         return (elementSize, numberOfBytes, elementCount)

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -108,17 +108,16 @@ extension Collection where Element == Byte {
     /// Check if a sequence of ``Bytes`` can be safely mapped to a collection of elements of a given size.
     /// - Parameter targetSize: The size of element to map to.
     /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
-    /// - Returns: `(elementSize: Int, numberOfBytes: Int, elementCount: Int)`, to aid in building the new collection.
+    /// - Returns: `(numberOfBytes: Int, elementCount: Int)`, to aid in building the new collection.
     @inlinable
     func canBeMapped(
         to targetSize: Int
     ) throws(BytesError.BufferSizeError) -> (numberOfBytes: Int, elementCount: Int) {
-        let elementSize = targetSize
         let numberOfBytes = self.count
-        let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: elementSize)
+        let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: targetSize)
         
         guard remainingElementSize == 0 else {
-            throw .invalidBufferSize(targetSize: (elementCount+1)*elementSize, targetType: "Bytes<\(elementSize)>", actualSize: numberOfBytes)
+            throw .invalidBufferSize(targetSize: (elementCount+1)*targetSize, targetType: "Bytes<\(targetSize)>", actualSize: numberOfBytes)
         }
         
         return (numberOfBytes, elementCount)

--- a/Tests/BytesTests/BytesTests.swift
+++ b/Tests/BytesTests/BytesTests.swift
@@ -27,39 +27,15 @@ extension BytesError {
         switch expressionResult {
         case
             let BytesError.BufferSizeError.invalidBufferSize(a1, a2, a3),
-            let BytesError.ContiguousBytes.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
             let BytesError.UUIDDecoding.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
             let BytesError.RawRepresentable.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)),
-            let BytesError.RawRepresentable.ContiguousBytes.BufferSizeError.castingFailure(.castingFailure(.invalidBufferSize(a1, a2, a3))),
-            let BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(a1, a2, a3)):
+            let BytesError.RawRepresentable.ContiguousBytes.BufferSizeError.castingFailure(.castingFailure(.invalidBufferSize(a1, a2, a3))):
             XCTAssertEqual(a1, try targetSize(), messageResult, file: (file), line: line)
             XCTAssertEqual(a2, try targetType(), messageResult, file: (file), line: line)
             XCTAssertEqual(a3, try actualSize(), messageResult, file: (file), line: line)
         default:
             if messageResult.isEmpty {
                 XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.invalidMemorySize", file: (file), line: line)
-            } else {
-                XCTFail(messageResult, file: (file), line: line)
-            }
-        }
-    }
-    
-    static func testContiguousMemoryUnavailable(
-        _ expression: @autoclosure () throws -> any Error,
-        collectionType: @autoclosure () throws -> String,
-        _ message: @autoclosure () -> String = "",
-        file: StaticString = #file,
-        line: UInt = #line
-    ) rethrows {
-        let expressionResult = try expression()
-        let messageResult = message()
-        
-        switch expressionResult {
-        case let BytesError.ContiguousBytes.BufferSizeError.contiguousBytesUnavailable(a1):
-            XCTAssertEqual(a1, try collectionType(), messageResult, file: (file), line: line)
-        default:
-            if messageResult.isEmpty {
-                XCTFail("\(type(of: expressionResult)).\(expressionResult) is not BytesError.contiguousMemoryUnavailable", file: (file), line: line)
             } else {
                 XCTFail(messageResult, file: (file), line: line)
             }

--- a/Tests/BytesTests/CastingTests.swift
+++ b/Tests/BytesTests/CastingTests.swift
@@ -172,15 +172,15 @@ import Testing
         
         let incompleteBytes: Bytes = [0x00,0x01,0x00,0x10,0x01,0x00,0x10]
         /// Explicit thyped throw.
-        #expect(throws: BytesError.Transformation<BytesError.BufferSizeError>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<BytesError.BufferSizeError>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16<4>", actualSize: 7))) {
             try [UInt16](bytes: incompleteBytes) { (bytes) throws(BytesError.BufferSizeError) -> UInt16 in try bytes.casting(to: UInt16.self).bigEndian }
         }
         
         /// Implicit any Error checks.
-        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16<4>", actualSize: 7))) {
             try [UInt16](bytes: incompleteBytes) { try $0.casting(to: UInt16.self).bigEndian }
         }
-        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt32", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt32<2>", actualSize: 7))) {
             try [UInt16](bytes: incompleteBytes, element: UInt32.self) { try $0.casting(to: UInt16.self).bigEndian }
         }
         #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "Bytes<2>", actualSize: 7))) {
@@ -188,7 +188,7 @@ import Testing
         }
         
         /// Make sure transformation is never called.
-        #expect(throws: BytesError.Transformation<Never>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<Never>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16<4>", actualSize: 7))) {
             try [UInt16](bytes: incompleteBytes) { _ in
                 Issue.record("Should never be called.")
                 fatalError()
@@ -225,15 +225,15 @@ import Testing
         
         let incompleteBytes: Bytes = [0x00,0x01,0x00,0x10,0x01,0x00,0x10]
         /// Explicit thyped throw.
-        #expect(throws: BytesError.Transformation<BytesError.BufferSizeError>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<BytesError.BufferSizeError>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16<4>", actualSize: 7))) {
             try Set<UInt16>(bytes: incompleteBytes) { (bytes) throws(BytesError.BufferSizeError) -> UInt16 in try bytes.casting(to: UInt16.self).bigEndian }
         }
         
         /// Implicit any Error checks.
-        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16<4>", actualSize: 7))) {
             try Set<UInt16>(bytes: incompleteBytes) { try $0.casting(to: UInt16.self).bigEndian }
         }
-        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt32", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt32<2>", actualSize: 7))) {
             try Set<UInt16>(bytes: incompleteBytes, element: UInt32.self) { try $0.casting(to: UInt16.self).bigEndian }
         }
         #expect(throws: BytesError.Transformation<any Error>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "Bytes<2>", actualSize: 7))) {
@@ -241,7 +241,7 @@ import Testing
         }
         
         /// Make sure transformation is never called.
-        #expect(throws: BytesError.Transformation<Never>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16", actualSize: 7))) {
+        #expect(throws: BytesError.Transformation<Never>.BufferSizeError.castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt16<4>", actualSize: 7))) {
             try Set<UInt16>(bytes: incompleteBytes) { _ in
                 Issue.record("Should never be called.")
                 fatalError()

--- a/Tests/BytesTests/IntegerTests.swift
+++ b/Tests/BytesTests/IntegerTests.swift
@@ -132,10 +132,10 @@ final class IntegerTests: XCTestCase {
         
         let invalidBytes: Bytes = [0x00,0x01,0x00,0x10,0x01,0x00,0x10]
         XCTAssertThrowsError(try [UInt16](bigEndianBytes: invalidBytes)) {
-            BytesError.testInvalidMemorySize($0, targetSize: 8, targetType: "UInt16", actualSize: 7)
+            BytesError.testInvalidMemorySize($0, targetSize: 8, targetType: "UInt16<4>", actualSize: 7)
         }
         XCTAssertThrowsError(try [UInt16](littleEndianBytes: invalidBytes)) {
-            BytesError.testInvalidMemorySize($0, targetSize: 8, targetType: "UInt16", actualSize: 7)
+            BytesError.testInvalidMemorySize($0, targetSize: 8, targetType: "UInt16<4>", actualSize: 7)
         }
     }
     

--- a/Tests/BytesTests/RawRepresentableTests.swift
+++ b/Tests/BytesTests/RawRepresentableTests.swift
@@ -117,16 +117,16 @@ final class RawRepresentableTests: XCTestCase {
             BytesError.testInvalidRawRepresentableByteSequence($0)
         }
         XCTAssertThrowsError(try [IntEnum](bigEndianBytes: [0x00])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16", actualSize: 1)
+            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16<1>", actualSize: 1)
         }
         XCTAssertThrowsError(try [IntEnum](littleEndianBytes: [0x00])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16", actualSize: 1)
+            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16<1>", actualSize: 1)
         }
         XCTAssertThrowsError(try Set<IntEnum>(bigEndianBytes: [0x00])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16", actualSize: 1)
+            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16<1>", actualSize: 1)
         }
         XCTAssertThrowsError(try Set<IntEnum>(littleEndianBytes: [0x00])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16", actualSize: 1)
+            BytesError.testInvalidMemorySize($0, targetSize: 2, targetType: "UInt16<1>", actualSize: 1)
         }
         
         XCTAssertEqual(try StringEnum(utf8Bytes: [0x61]), .a)

--- a/Tests/BytesTests/UUIDTests.swift
+++ b/Tests/BytesTests/UUIDTests.swift
@@ -36,10 +36,10 @@ final class UUIDTests: XCTestCase {
         XCTAssertEqual(try [UUID](bytes: []), [])
         XCTAssertEqual(try Set<UUID>(bytes: []), [])
         XCTAssertThrowsError(try [UUID](bytes: rawUUIDBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)", actualSize: 17)
+            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 17)
         }
         XCTAssertThrowsError(try Set<UUID>(bytes: rawUUIDBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)", actualSize: 17)
+            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 17)
         }
         
         XCTAssertEqual(try [UUID](stringBytes: rawUUIDStringBytes+rawUUIDStringBytes), [validUUID, validUUID])
@@ -47,10 +47,10 @@ final class UUIDTests: XCTestCase {
         XCTAssertEqual(try [UUID](stringBytes: []), [])
         XCTAssertEqual(try Set<UUID>(stringBytes: []), [])
         XCTAssertThrowsError(try [UUID](stringBytes: rawUUIDStringBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)", actualSize: 37)
+            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 37)
         }
         XCTAssertThrowsError(try Set<UUID>(stringBytes: rawUUIDStringBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)", actualSize: 37)
+            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 37)
         }
         XCTAssertThrowsError(try [UUID](stringBytes: "000000000000000000000000000000000000000000000000000000000000000000000000".utf8Bytes)) {
             BytesError.testInvalidUUIDByteSequence($0)


### PR DESCRIPTION
- Fixed documentation regression for newly added byte mapping internal method.
- Updated casting errors to indicate the size and number of elements that were being decoded.