### PR TITLE
Error Type Fixes

### DIFF
--- a/Sources/Bytes/ByteIterator.swift
+++ b/Sources/Bytes/ByteIterator.swift
@@ -60,7 +60,7 @@ extension IteratorProtocol where Element == Byte {
         }
         
         guard result.count >= minCount else {
-            throw .invalidBufferSize(targetSize: minCount, targetType: "Bytes", actualSize: result.count)
+            throw .invalidBufferSize(targetSize: minCount, targetType: targetType, actualSize: result.count)
         }
         
         return result

--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -10,25 +10,32 @@
 extension Collection where Element == Byte {
     /// Check if a sequence of ``Bytes`` can be safely casted to an element.
     /// - Parameter target: The type of element to cast to.
+    /// - Parameter targetType: An optional name to report when throwing errors.
     /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the size of the bytes sequence is not equal to the element's size.
     @inlinable
-    func canBeCasted<Element>(to target: Element.Type) throws(BytesError.BufferSizeError) {
+    func canBeCasted<Element>(
+        to target: Element.Type,
+        targetType: String? = nil
+    ) throws(BytesError.BufferSizeError) {
         guard MemoryLayout<Element>.size == self.count else {
-            throw .invalidBufferSize(targetSize: MemoryLayout<Element>.size, targetType: "\(Element.self)", actualSize: self.count)
+            throw .invalidBufferSize(targetSize: MemoryLayout<Element>.size, targetType: targetType ?? "\(Element.self)", actualSize: self.count)
         }
     }
     
     /// Cast an _entire_ ``Bytes`` sequence to the lhs's type.
+    /// - Parameter target: The type of element to cast to.
+    /// - Parameter targetType: An optional name to report when throwing errors.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
     ///     - ``BytesError/ContiguousBytesError/contiguousBytesUnavailable(type:)-enum.case`` if contiguous memory could not be made available.
     /// - Returns: An instance represented by the ``Bytes`` sequence.
     @inlinable
     public func casting<R>(
-        to target: R.Type = R.self
+        to target: R.Type = R.self,
+        targetType: String? = nil
     ) throws(BytesError.ContiguousBytes.BufferSizeError) -> R {
         do {
-            try canBeCasted(to: R.self)
+            try canBeCasted(to: R.self, targetType: targetType)
         } catch {
             throw .castingFailure(error)
         }
@@ -48,14 +55,17 @@ extension Collection where Element == Byte {
     
     /// Cast an _entire_ ``Bytes`` sequence to the lhs's type, copying buffers if needed no matter the size.
     /// - Warning: Only use this variant if you are absolutely certain the number of bytes to be copied won't have performance repercussions.
+    /// - Parameter target: The type of element to cast to.
+    /// - Parameter targetType: An optional name to report when throwing errors.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
     /// - Returns: An instance represented by the ``Bytes`` sequence.
     @inlinable
     public func contiguousCasting<R>(
-        to target: R.Type = R.self
+        to target: R.Type = R.self,
+        targetType: String? = nil
     ) throws(BytesError.BufferSizeError) -> R {
-        try canBeCasted(to: R.self)
+        try canBeCasted(to: R.self, targetType: targetType)
         
         if let result = self.withContiguousStorageIfAvailable({
             UnsafeRawBufferPointer($0).loadUnaligned(as: R.self)
@@ -68,14 +78,17 @@ extension Collection where Element == Byte {
     }
     
     /// Cast an _entire_ ``Bytes`` sequence to the lhs's type.
+    /// - Parameter target: The type of element to cast to.
+    /// - Parameter targetType: An optional name to report when throwing errors.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the memory layout of the bytes sequence does not match the desired type.
     /// - Returns: An instance represented by the ``Bytes`` sequence.
     @inlinable
     public func casting<R>(
-        to target: R.Type = R.self
+        to target: R.Type = R.self,
+        targetType: String? = nil
     ) throws(BytesError.BufferSizeError) -> R where Self: ContiguousBytesCollection {
-        try canBeCasted(to: R.self)
+        try canBeCasted(to: R.self, targetType: targetType)
         return self.withUnsafeBytes { $0.loadUnaligned(as: R.self) }
     }
     
@@ -88,18 +101,20 @@ extension Collection where Element == Byte {
     
     /// Check if a sequence of ``Bytes`` can be safely mapped to a collection of elements.
     /// - Parameter target: The type of element to map to.
+    /// - Parameter targetType: An optional name to report when throwing errors.
     /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     /// - Returns: `(elementSize: Int, elementCount: Int)`, to aid in building the new collection.
     @inlinable
     func canBeMapped<Element>(
-        to target: Element.Type
+        to target: Element.Type,
+        targetType: String?
     ) throws(BytesError.BufferSizeError) -> (elementSize: Int, elementCount: Int) {
         let elementSize = MemoryLayout<Element>.size
         let numberOfBytes = self.count
         let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: elementSize)
         
         guard remainingElementSize == 0 else {
-            throw .invalidBufferSize(targetSize: (elementCount + 1)*elementSize, targetType: "\(Element.self)<\(elementCount + 1)>", actualSize: numberOfBytes)
+            throw .invalidBufferSize(targetSize: (elementCount + 1)*elementSize, targetType: "\(targetType ?? "\(Element.self)")<\(elementCount + 1)>", actualSize: numberOfBytes)
         }
         
         return (elementSize, elementCount)
@@ -107,17 +122,19 @@ extension Collection where Element == Byte {
     
     /// Check if a sequence of ``Bytes`` can be safely mapped to a collection of elements of a given size.
     /// - Parameter targetSize: The size of element to map to.
+    /// - Parameter targetType: An optional name to report when throwing errors.
     /// - Throws: ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     /// - Returns: the number of elements to aid in building the new collection.
     @inlinable
     func canBeMapped(
-        to targetSize: Int
+        to targetSize: Int,
+        targetType: String
     ) throws(BytesError.BufferSizeError) -> Int {
         let numberOfBytes = self.count
         let (elementCount, remainingElementSize) = numberOfBytes.quotientAndRemainder(dividingBy: targetSize)
         
         guard remainingElementSize == 0 else {
-            throw .invalidBufferSize(targetSize: (elementCount+1)*targetSize, targetType: "Bytes<\(targetSize)>", actualSize: numberOfBytes)
+            throw .invalidBufferSize(targetSize: (elementCount+1)*targetSize, targetType: "\(targetType)<\(targetSize)>", actualSize: numberOfBytes)
         }
         
         return elementCount
@@ -153,6 +170,7 @@ extension RangeReplaceableCollection {
     /// Creates a new collection from a sequence of bytes, transforming batches of bytes into the element type of the collection.
     /// - Parameters:
     ///   - bytes: The bytes to transform.
+    ///   - targetType: An optional name to report when throwing errors.
     ///   - transform: The transformation to perform on each element.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
@@ -165,9 +183,10 @@ extension RangeReplaceableCollection {
         TransformationFailure: Error
     >(
         bytes: Bytes,
+        targetType: String? = nil,
         mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
     ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
-        try self.init(bytes: bytes, element: Element.self, mapping: transform)
+        try self.init(bytes: bytes, element: Element.self, targetType: targetType, mapping: transform)
     }
     
     /// Creates a new collection from a sequence of bytes, transforming batches of bytes into the specified element type.
@@ -176,6 +195,7 @@ extension RangeReplaceableCollection {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - element: The element that was used to encode the byte sequence.
+    ///   - targetType: An optional name to report when throwing errors.
     ///   - transform: The transformation to perform on each element.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
@@ -190,12 +210,13 @@ extension RangeReplaceableCollection {
     >(
         bytes: Bytes,
         element: EncodedElement.Type,
+        targetType: String? = nil,
         mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
     ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
         let elementSize: Int
         let elementCount: Int
         do {
-            (elementSize, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+            (elementSize, elementCount) = try bytes.canBeMapped(to: EncodedElement.self, targetType: targetType)
         } catch {
             throw .castingFailure(error)
         }
@@ -224,6 +245,7 @@ extension RangeReplaceableCollection {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - elementSize: The size of the element that was used to encode the byte sequence.
+    ///   - targetType: An optional name to report when throwing errors.
     ///   - transform: The transformation to perform on each element.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
@@ -237,11 +259,12 @@ extension RangeReplaceableCollection {
     >(
         bytes: Bytes,
         elementSize: Int,
+        targetType: String = "Bytes",
         mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
     ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
         let elementCount: Int
         do {
-            elementCount = try bytes.canBeMapped(to: elementSize)
+            elementCount = try bytes.canBeMapped(to: elementSize, targetType: targetType)
         } catch {
             throw .castingFailure(error)
         }
@@ -269,6 +292,7 @@ extension Set {
     /// Creates a new Set from a sequence of bytes, transforming batches of bytes into the element type of the Set.
     /// - Parameters:
     ///   - bytes: The bytes to transform.
+    ///   - targetType: An optional name to report when throwing errors.
     ///   - transform: The transformation to perform on each element.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
@@ -281,9 +305,10 @@ extension Set {
         TransformationFailure: Error
     >(
         bytes: Bytes,
+        targetType: String? = nil,
         mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
     ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
-        try self.init(bytes: bytes, element: Element.self, mapping: transform)
+        try self.init(bytes: bytes, element: Element.self, targetType: targetType, mapping: transform)
     }
     
     /// Creates a new Set from a sequence of bytes, transforming batches of bytes into the specified element type.
@@ -292,6 +317,7 @@ extension Set {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - element: The element that was used to encode the byte sequence.
+    ///   - targetType: An optional name to report when throwing errors.
     ///   - transform: The transformation to perform on each element.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
@@ -306,12 +332,13 @@ extension Set {
     >(
         bytes: Bytes,
         element: EncodedElement.Type,
+        targetType: String? = nil,
         mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
     ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
         let elementSize: Int
         let elementCount: Int
         do {
-            (elementSize, elementCount) = try bytes.canBeMapped(to: EncodedElement.self)
+            (elementSize, elementCount) = try bytes.canBeMapped(to: EncodedElement.self, targetType: targetType)
         } catch {
             throw .castingFailure(error)
         }
@@ -340,6 +367,7 @@ extension Set {
     /// - Parameters:
     ///   - bytes: The bytes to transform.
     ///   - elementSize: The size of the element that was used to encode the byte sequence.
+    ///   - targetType: An optional name to report when throwing errors.
     ///   - transform: The transformation to perform on each element.
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
@@ -353,11 +381,12 @@ extension Set {
     >(
         bytes: Bytes,
         elementSize: Int,
+        targetType: String = "Bytes",
         mapping transform: (Bytes.SubSequence) throws(TransformationFailure) -> Self.Element
     ) throws(BytesError.Transformation<TransformationFailure>.BufferSizeError) {
         let elementCount: Int
         do {
-            elementCount = try bytes.canBeMapped(to: elementSize)
+            elementCount = try bytes.canBeMapped(to: elementSize, targetType: targetType)
         } catch {
             throw .castingFailure(error)
         }

--- a/Sources/Bytes/Integer.swift
+++ b/Sources/Bytes/Integer.swift
@@ -253,7 +253,7 @@ extension IteratorProtocol where Element == Byte {
     public mutating func nextIfPresent<T: FixedWidthInteger>(
         littleEndian type: T.Type
     ) throws(BytesError.BufferSizeError) -> T? {
-        guard let bytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+        guard let bytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size, targetType: "\(T.self)")
         else { return nil }
         return try T(littleEndianBytes: bytes)
     }
@@ -270,7 +270,7 @@ extension IteratorProtocol where Element == Byte {
     public mutating func nextIfPresent<T: FixedWidthInteger>(
         bigEndian type: T.Type
     ) throws(BytesError.BufferSizeError) -> T? {
-        guard let bytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+        guard let bytes = try nextIfPresent(Bytes.self, count: MemoryLayout<T>.size, targetType: "\(T.self)")
         else { return nil }
         return try T(bigEndianBytes: bytes)
     }
@@ -407,7 +407,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         littleEndian type: T.Type
     ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> T? {
         /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size, targetType: "\(T.self)")
             .map { try! T(littleEndianBytes: $0) }
     }
     
@@ -430,7 +430,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         bigEndian type: T.Type
     ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> T? {
         /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size, targetType: "\(T.self)")
             .map { try! T(bigEndianBytes: $0) }
     }
     
@@ -581,7 +581,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         isolation actor: isolated (any Actor)? = #isolation
     ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> T? {
         /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size, targetType: "\(T.self)")
             .map { try! T(littleEndianBytes: $0) }
     }
     
@@ -602,7 +602,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         isolation actor: isolated (any Actor)? = #isolation
     ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> T? {
         /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size)
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<T>.size, targetType: "\(T.self)")
             .map { try! T(bigEndianBytes: $0) }
     }
     

--- a/Sources/Bytes/UUID.swift
+++ b/Sources/Bytes/UUID.swift
@@ -43,7 +43,7 @@ extension UUID {
     public init<Bytes: BytesCollection>(
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) {
-        self.init(uuid: try bytes.contiguousCasting())
+        self.init(uuid: try bytes.contiguousCasting(targetType: "UUID(Byte<16>)"))
     }
     
     /// Initialize a UUID from a contiguous sequence of Bytes representing the 16-byte compact format.
@@ -54,7 +54,7 @@ extension UUID {
     public init<Bytes: ContiguousBytesCollection>(
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) {
-        self.init(uuid: try bytes.casting())
+        self.init(uuid: try bytes.casting(targetType: "UUID(Byte<16>)"))
     }
     
     /// The 36-character Byte representation of a UUID.
@@ -73,7 +73,7 @@ extension UUID {
         stringBytes: Bytes
     ) throws(BytesError.UUIDDecoding.BufferSizeError) {
         do {
-            try stringBytes.canBeCasted(to: UUIDTextualBytes.self)
+            try stringBytes.canBeCasted(to: UUIDTextualBytes.self, targetType: "UUID(Byte<36>)")
         } catch {
             throw .castingFailure(error)
         }
@@ -102,7 +102,7 @@ extension Collection where Element == UUID {
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) where Self: RangeReplaceableCollection {
         do {
-            try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+            try self.init(bytes: bytes, element: uuid_t.self, targetType: "UUID(Byte<16>)", mapping: Element.init(bytes:))
         } catch {
             throw error.flattened
         }
@@ -117,7 +117,7 @@ extension Collection where Element == UUID {
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) where Self: RangeReplaceableCollection, Bytes.SubSequence: ContiguousBytesCollection {
         do {
-            try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+            try self.init(bytes: bytes, element: uuid_t.self, targetType: "UUID(Byte<16>)", mapping: Element.init(bytes:))
         } catch {
             throw error.flattened
         }
@@ -139,7 +139,7 @@ extension Collection where Element == UUID {
         stringBytes: Bytes
     ) throws(BytesError.UUIDDecoding.BufferSizeError) where Self: RangeReplaceableCollection {
         do {
-            try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, mapping: Element.init(stringBytes:))
+            try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, targetType: "UUID(Byte<36>)", mapping: Element.init(stringBytes:))
         } catch {
             throw error.flattened
         }
@@ -158,7 +158,7 @@ extension Set where Element == UUID {
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) {
         do {
-            try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+            try self.init(bytes: bytes, element: uuid_t.self, targetType: "UUID(Byte<16>)", mapping: Element.init(bytes:))
         } catch {
             throw error.flattened
         }
@@ -173,7 +173,7 @@ extension Set where Element == UUID {
         bytes: Bytes
     ) throws(BytesError.BufferSizeError) where Bytes.SubSequence: ContiguousBytesCollection {
         do {
-            try self.init(bytes: bytes, element: uuid_t.self, mapping: Element.init(bytes:))
+            try self.init(bytes: bytes, element: uuid_t.self, targetType: "UUID(Byte<16>)", mapping: Element.init(bytes:))
         } catch {
             throw error.flattened
         }
@@ -189,7 +189,7 @@ extension Set where Element == UUID {
         stringBytes: Bytes
     ) throws(BytesError.UUIDDecoding.BufferSizeError) {
         do {
-            try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, mapping: Element.init(stringBytes:))
+            try self.init(bytes: stringBytes, element: UUIDTextualBytes.self, targetType: "UUID(Byte<36>)", mapping: Element.init(stringBytes:))
         } catch {
             throw error.flattened
         }
@@ -210,7 +210,7 @@ extension IteratorProtocol where Element == Byte {
     public mutating func next(
         _ type: UUID.Type
     ) throws(BytesError.BufferSizeError) -> UUID {
-        try UUID(bytes: try next(Bytes.self, count: MemoryLayout<uuid_t>.size))
+        try UUID(bytes: try next(Bytes.self, count: MemoryLayout<uuid_t>.size, targetType: "UUID(Byte<16>)"))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -227,7 +227,7 @@ extension IteratorProtocol where Element == Byte {
     ) throws(BytesError.UUIDDecoding.BufferSizeError) -> UUID {
         let stringBytes: Bytes
         do {
-            stringBytes = try next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+            stringBytes = try next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size, targetType: "UUID(Byte<36>)")
         } catch {
             throw .castingFailure(error)
         }
@@ -244,7 +244,7 @@ extension IteratorProtocol where Element == Byte {
     public mutating func nextIfPresent(
         _ type: UUID.Type
     ) throws(BytesError.BufferSizeError) -> UUID? {
-        guard let bytes = try nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size)
+        guard let bytes = try nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size, targetType: "UUID(Byte<16>)")
         else { return nil }
         return try UUID(bytes: bytes)
     }
@@ -263,7 +263,7 @@ extension IteratorProtocol where Element == Byte {
     ) throws(BytesError.UUIDDecoding.BufferSizeError) -> UUID? {
         let stringBytes: Bytes?
         do {
-            stringBytes = try nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+            stringBytes = try nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size, targetType: "UUID(Byte<36>)")
         } catch {
             throw .castingFailure(error)
         }
@@ -367,7 +367,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         _ type: UUID.Type
     ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> UUID {
         /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
-        try! UUID(bytes: try await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
+        try! UUID(bytes: try await next(Bytes.self, count: MemoryLayout<uuid_t>.size, targetType: "UUID(Byte<16>)"))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -389,7 +389,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     ) async throws(BytesError.Iteration<any Error>.UUIDDecoding.BufferSizeError) -> UUID {
         let stringBytes: Bytes
         do {
-            stringBytes = try await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+            stringBytes = try await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size, targetType: "UUID(Byte<36>)")
         } catch {
             throw error.mapCastingFailure { .castingFailure($0) }
         }
@@ -417,7 +417,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         _ type: UUID.Type
     ) async throws(BytesError.Iteration<any Error>.BufferSizeError) -> UUID? {
         /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size)
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size, targetType: "UUID(Byte<16>)")
             .map { try! UUID(bytes: $0) }
     }
     
@@ -440,7 +440,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     ) async throws(BytesError.Iteration<any Error>.UUIDDecoding.BufferSizeError) -> UUID? {
         let stringBytes: Bytes?
         do {
-            stringBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+            stringBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size, targetType: "UUID(Byte<36>)")
         } catch {
             throw error.mapCastingFailure { .castingFailure($0) }
         }
@@ -567,7 +567,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         isolation actor: isolated (any Actor)? = #isolation
     ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> UUID {
         /// We know the inner `try` validates the size already, so the outer one can never fail, and we can simplify the reported error types.
-        try! UUID(bytes: try await next(Bytes.self, count: MemoryLayout<uuid_t>.size))
+        try! UUID(bytes: try await next(Bytes.self, count: MemoryLayout<uuid_t>.size, targetType: "UUID(Byte<16>)"))
     }
     
     /// Asynchronously advances to the next UUID String, or throws if it could not.
@@ -587,7 +587,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     ) async throws(BytesError.Iteration<Failure>.UUIDDecoding.BufferSizeError) -> UUID {
         let stringBytes: Bytes
         do {
-            stringBytes = try await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+            stringBytes = try await next(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size, targetType: "UUID(Byte<36>)")
         } catch {
             throw error.mapCastingFailure { .castingFailure($0) }
         }
@@ -613,7 +613,7 @@ extension AsyncIteratorProtocol where Element == Byte {
         isolation actor: isolated (any Actor)? = #isolation
     ) async throws(BytesError.Iteration<Failure>.BufferSizeError) -> UUID? {
         /// We know the first `try` validates the size already, so the mapped one can never fail, and we can simplify the reported error types.
-        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size)
+        try await nextIfPresent(Bytes.self, count: MemoryLayout<uuid_t>.size, targetType: "UUID(Byte<16>)")
             .map { try! UUID(bytes: $0) }
     }
     
@@ -634,7 +634,7 @@ extension AsyncIteratorProtocol where Element == Byte {
     ) async throws(BytesError.Iteration<Failure>.UUIDDecoding.BufferSizeError) -> UUID? {
         let stringBytes: Bytes?
         do {
-            stringBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size)
+            stringBytes = try await nextIfPresent(Bytes.self, count: MemoryLayout<UUIDTextualBytes>.size, targetType: "UUID(Byte<36>)")
         } catch {
             throw error.mapCastingFailure { .castingFailure($0) }
         }

--- a/Tests/BytesTests/IntegerTests.swift
+++ b/Tests/BytesTests/IntegerTests.swift
@@ -722,7 +722,7 @@ import Testing
             #expect(try iterator.next(littleEndian: UInt16.self) == 0x0201)
             #expect(try iterator.next(littleEndian: UInt32.self) == 0x0605_0403)
             
-            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1)) {
+            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1)) {
                 try iterator.next(littleEndian: UInt64.self)
             }
         }
@@ -733,7 +733,7 @@ import Testing
             #expect(try iterator.next(bigEndian: UInt16.self) == 0x0102)
             #expect(try iterator.next(bigEndian: UInt32.self) == 0x0304_0506)
             
-            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1)) {
+            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1)) {
                 try iterator.next(bigEndian: UInt64.self)
             }
         }

--- a/Tests/BytesTests/IntegerTests.swift
+++ b/Tests/BytesTests/IntegerTests.swift
@@ -744,7 +744,7 @@ import Testing
             #expect(try iterator.nextIfPresent(littleEndian: UInt16.self) == 0x0201)
             #expect(try iterator.nextIfPresent(littleEndian: UInt32.self) == 0x0605_0403)
             
-            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1)) {
+            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1)) {
                 try iterator.nextIfPresent(littleEndian: UInt64.self)
             }
             
@@ -757,7 +757,7 @@ import Testing
             #expect(try iterator.nextIfPresent(bigEndian: UInt16.self) == 0x0102)
             #expect(try iterator.nextIfPresent(bigEndian: UInt32.self) == 0x0304_0506)
             
-            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1)) {
+            #expect(throws: BytesError.BufferSizeError.invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1)) {
                 try iterator.nextIfPresent(bigEndian: UInt64.self)
             }
             
@@ -893,7 +893,7 @@ import Testing
                 _ = try await iterator.nextIfPresent(littleEndian: UInt64.self)
                 Issue.record("Error was expected here")
             } catch {
-                guard error == .castingFailure(.invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1))
+                guard error == .castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1))
                 else { throw error }
             }
             
@@ -927,7 +927,7 @@ import Testing
                 _ = try await iterator.nextIfPresent(bigEndian: UInt64.self)
                 Issue.record("Error was expected here")
             } catch {
-                guard error == .invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1)
+                guard error == .invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1)
                 else { throw error }
             }
             
@@ -1193,7 +1193,7 @@ import Testing
                 _ = try await iterator.nextIfPresent(littleEndian: UInt64.self)
                 Issue.record("Error was expected here")
             } catch {
-                guard error == .castingFailure(.invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1))
+                guard error == .castingFailure(.invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1))
                 else { throw error }
             }
             
@@ -1229,7 +1229,7 @@ import Testing
                 _ = try await iterator.nextIfPresent(bigEndian: UInt64.self)
                 Issue.record("Error was expected here")
             } catch {
-                guard error == .invalidBufferSize(targetSize: 8, targetType: "Bytes", actualSize: 1)
+                guard error == .invalidBufferSize(targetSize: 8, targetType: "UInt64", actualSize: 1)
                 else { throw error }
             }
             

--- a/Tests/BytesTests/UUIDTests.swift
+++ b/Tests/BytesTests/UUIDTests.swift
@@ -22,10 +22,10 @@ final class UUIDTests: XCTestCase {
         XCTAssertEqual(try UUID(stringBytes: rawUUIDStringBytes), validUUID)
         
         XCTAssertThrowsError(try UUID(bytes: [])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 16, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)", actualSize: 0)
+            BytesError.testInvalidMemorySize($0, targetSize: 16, targetType: "UUID(Byte<16>)", actualSize: 0)
         }
         XCTAssertThrowsError(try UUID(stringBytes: [])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 36, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)", actualSize: 0)
+            BytesError.testInvalidMemorySize($0, targetSize: 36, targetType: "UUID(Byte<36>)", actualSize: 0)
         }
         XCTAssertThrowsError(try UUID(stringBytes: "000000000000000000000000000000000000".utf8Bytes)) {
             BytesError.testInvalidUUIDByteSequence($0)
@@ -36,10 +36,10 @@ final class UUIDTests: XCTestCase {
         XCTAssertEqual(try [UUID](bytes: []), [])
         XCTAssertEqual(try Set<UUID>(bytes: []), [])
         XCTAssertThrowsError(try [UUID](bytes: rawUUIDBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 17)
+            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "UUID(Byte<16>)<2>", actualSize: 17)
         }
         XCTAssertThrowsError(try Set<UUID>(bytes: rawUUIDBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 17)
+            BytesError.testInvalidMemorySize($0, targetSize: 32, targetType: "UUID(Byte<16>)<2>", actualSize: 17)
         }
         
         XCTAssertEqual(try [UUID](stringBytes: rawUUIDStringBytes+rawUUIDStringBytes), [validUUID, validUUID])
@@ -47,10 +47,10 @@ final class UUIDTests: XCTestCase {
         XCTAssertEqual(try [UUID](stringBytes: []), [])
         XCTAssertEqual(try Set<UUID>(stringBytes: []), [])
         XCTAssertThrowsError(try [UUID](stringBytes: rawUUIDStringBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 37)
+            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "UUID(Byte<36>)<2>", actualSize: 37)
         }
         XCTAssertThrowsError(try Set<UUID>(stringBytes: rawUUIDStringBytes+[0])) {
-            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)<2>", actualSize: 37)
+            BytesError.testInvalidMemorySize($0, targetSize: 72, targetType: "UUID(Byte<36>)<2>", actualSize: 37)
         }
         XCTAssertThrowsError(try [UUID](stringBytes: "000000000000000000000000000000000000000000000000000000000000000000000000".utf8Bytes)) {
             BytesError.testInvalidUUIDByteSequence($0)


### PR DESCRIPTION
- Fixed an issue where UUIDs did not report the correct type in errors.
- Fixed an issue where requesting next bytes would not fail with the correct target type.
- Fixed an issue where not all Integer iterator methods threw errors that specified the correct integer type in the error.