### PR TITLE
Documentation Mismatches

### DIFF
--- a/Sources/Bytes/Colletion+Casting.swift
+++ b/Sources/Bytes/Colletion+Casting.swift
@@ -175,8 +175,8 @@ extension RangeReplaceableCollection {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
-    /// - SeeAlso: ``init(bytes:element:mapping:)`` for when an element's memory layout can be used to infer the size.
-    /// - SeeAlso: ``init(bytes:elementSize:mapping:)`` for when its not suitable to infer the size of an element from its memory layout.  
+    /// - SeeAlso: ``init(bytes:element:targetType:mapping:)`` for when an element's memory layout can be used to infer the size.
+    /// - SeeAlso: ``init(bytes:elementSize:targetType:mapping:)`` for when its not suitable to infer the size of an element from its memory layout.
     @inlinable
     public init<
         Bytes: BytesCollection,
@@ -200,8 +200,8 @@ extension RangeReplaceableCollection {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
-    /// - SeeAlso: ``init(bytes:mapping:)`` for when the collection element matches the encoded element.
-    /// - SeeAlso: ``init(bytes:elementSize:mapping:)`` for when its not suitable to infer the size of an element from its memory layout.
+    /// - SeeAlso: ``init(bytes:targetType:mapping:)`` for when the collection element matches the encoded element.
+    /// - SeeAlso: ``init(bytes:elementSize:targetType:mapping:)`` for when its not suitable to infer the size of an element from its memory layout.
     @inlinable
     public init<
         Bytes: BytesCollection,
@@ -250,8 +250,8 @@ extension RangeReplaceableCollection {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
-    /// - SeeAlso: ``init(bytes:mapping:)`` for when the collection element matches the encoded element.
-    /// - SeeAlso: ``init(bytes:element:mapping:)`` for when an element's memory layout can be used to infer the size.
+    /// - SeeAlso: ``init(bytes:targetType:mapping:)`` for when the collection element matches the encoded element.
+    /// - SeeAlso: ``init(bytes:element:targetType:mapping:)`` for when an element's memory layout can be used to infer the size.
     @inlinable
     public init<
         Bytes: BytesCollection,
@@ -297,8 +297,8 @@ extension Set {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
-    /// - SeeAlso: ``init(bytes:element:mapping:)`` for when an element's memory layout can be used to infer the size.
-    /// - SeeAlso: ``init(bytes:elementSize:mapping:)`` for when its not suitable to infer the size of an element from its memory layout.
+    /// - SeeAlso: ``init(bytes:element:targetType:mapping:)`` for when an element's memory layout can be used to infer the size.
+    /// - SeeAlso: ``init(bytes:elementSize:targetType:mapping:)`` for when its not suitable to infer the size of an element from its memory layout.
     @inlinable
     public init<
         Bytes: BytesCollection,
@@ -322,8 +322,8 @@ extension Set {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
-    /// - SeeAlso: ``init(bytes:mapping:)`` for when the collection element matches the encoded element.
-    /// - SeeAlso: ``init(bytes:element:mapping:)`` for when an element's memory layout can be used to infer the size.
+    /// - SeeAlso: ``init(bytes:targetType:mapping:)`` for when the collection element matches the encoded element.
+    /// - SeeAlso: ``init(bytes:element:targetType:mapping:)`` for when an element's memory layout can be used to infer the size.
     @inlinable
     public init<
         Bytes: BytesCollection,
@@ -372,8 +372,8 @@ extension Set {
     /// - Throws:
     ///     - ``BytesError/BufferSizeError/invalidBufferSize(targetSize:targetType:actualSize:)`` if the total size of the bytes sequence is not a multiple of the element's size.
     ///     - ``BytesError/TransformationError/transformationFailure(_:)`` if the `transform` closure threw an error.
-    /// - SeeAlso: ``init(bytes:mapping:)`` for when the collection element matches the encoded element.
-    /// - SeeAlso: ``init(bytes:element:mapping:)`` for when an element's memory layout can be used to infer the size.
+    /// - SeeAlso: ``init(bytes:targetType:mapping:)`` for when the collection element matches the encoded element.
+    /// - SeeAlso: ``init(bytes:element:targetType:mapping:)`` for when an element's memory layout can be used to infer the size.
     @inlinable
     public init<
         Bytes: BytesCollection,

--- a/Sources/Bytes/String.swift
+++ b/Sources/Bytes/String.swift
@@ -287,9 +287,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     @inlinable
     @_disfavoredOverload
     public mutating func check(
-        utf8 string: Character
+        utf8 character: Character
     ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) {
-        try await check(string.utf8Bytes)
+        try await check(character.utf8Bytes)
     }
     
     /// Asynchronously advances by the specified UTF-8 encoded String if found, or throws if the next bytes in the iterator do not match.
@@ -333,9 +333,9 @@ extension AsyncIteratorProtocol where Element == Byte {
     @discardableResult
     @_disfavoredOverload
     public mutating func checkIfPresent(
-        utf8 string: Character
+        utf8 character: Character
     ) async throws(BytesError.Iteration<any Error>.SequenceCheckError) -> Bool {
-        try await checkIfPresent(string.utf8Bytes)
+        try await checkIfPresent(character.utf8Bytes)
     }
     
     /// Asynchronously advances by the specified UTF-8 encoded String if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.
@@ -460,10 +460,10 @@ extension AsyncIteratorProtocol where Element == Byte {
     ///     - ``BytesError/IterationError/iterationFailure(_:)`` if the underlying sequence threw an error while producing bytes.
     @inlinable
     public mutating func check(
-        utf8 string: Character,
+        utf8 character: Character,
         isolation actor: isolated (any Actor)? = #isolation
     ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) {
-        try await check(string.utf8Bytes)
+        try await check(character.utf8Bytes)
     }
     
     /// Asynchronously advances by the specified UTF-8 encoded String if found, or throws if the next bytes in the iterator do not match.
@@ -502,10 +502,10 @@ extension AsyncIteratorProtocol where Element == Byte {
     @inlinable
     @discardableResult
     public mutating func checkIfPresent(
-        utf8 string: Character,
+        utf8 character: Character,
         isolation actor: isolated (any Actor)? = #isolation
     ) async throws(BytesError.Iteration<Failure>.SequenceCheckError) -> Bool {
-        try await checkIfPresent(string.utf8Bytes)
+        try await checkIfPresent(character.utf8Bytes)
     }
     
     /// Asynchronously advances by the specified UTF-8 encoded String if found, throws if the next bytes in the iterator do not match, or returns false if the sequence ended.


### PR DESCRIPTION
- Fixed documentation comment mismatches for string casting.
- Fixed documentation comment mismatches for regular casting.